### PR TITLE
Fix reference to a non-existent package in demo.cfg

### DIFF
--- a/demo.cfg
+++ b/demo.cfg
@@ -6,7 +6,7 @@ auto-checkout +=
 [instance]
 eggs +=
     collective.contact.facetednav
-    collective.contact.list
+    collective.contact.contactlist
 zcml +=
     collective.contact.facetednav
-    collective.contact.list
+    collective.contact.contactlist


### PR DESCRIPTION
It would appear that collective.core.list does not exist.  I am updating this to point to what I think may have been intended, collective.contact.contactlist, which is in fact a released package available on PyPI
