### PR TITLE
Hide contact types from the navigation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.8 (unreleased)
 ----------------
 
+- Hide contact types from the navigation.
+  [pcdummy]
+
 - Sort sub organizations by folder position in organization view
   [sgeulette]
 
@@ -29,7 +32,7 @@ Changelog
   [cedricmessiant]
 
 - Fix prelabel_for_portal_type signature.
-  Some javascript fixes or improvements. 
+  Some javascript fixes or improvements.
   [vincentfretin]
 
 - Use different views/schemas for different use cases for add-contact widget

--- a/src/collective/contact/core/profiles/default/metadata.xml
+++ b/src/collective/contact/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>8</version>
+  <version>9</version>
   <dependencies>
     <dependency>profile-collective.contact.widget:default</dependency>
     <dependency>profile-plone.app.dexterity:default</dependency>

--- a/src/collective/contact/core/profiles/default/propertiestool.xml
+++ b/src/collective/contact/core/profiles/default/propertiestool.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+ <object name="navtree_properties" meta_type="Plone Property Sheet">
+    <property name="metaTypesNotToList" type="lines"
+              purge="False">
+      <element value="held_position"/>
+      <element value="organization"/>
+      <element value="person"/>
+      <element value="position"/>
+    </property>
+  </object>
+</object>

--- a/src/collective/contact/core/upgrades/configure.zcml
+++ b/src/collective/contact/core/upgrades/configure.zcml
@@ -93,4 +93,20 @@
       handler=".upgrades.v8"
       profile="collective.contact.core:default" />
 
+  <genericsetup:registerProfile
+      name="v9"
+      title="Migration profile for collective.contact.core to 9"
+      directory="profiles/v9"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      />
+
+  <genericsetup:upgradeStep
+      title="Upgrade from 8 to 9"
+      description="Hide contact types from the navigation"
+      source="8"
+      destination="9"
+      handler=".upgrades.v9"
+      profile="collective.contact.core:default" />
+
 </configure>

--- a/src/collective/contact/core/upgrades/profiles/v9/propertiestool.xml
+++ b/src/collective/contact/core/upgrades/profiles/v9/propertiestool.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+ <object name="navtree_properties" meta_type="Plone Property Sheet">
+    <property name="metaTypesNotToList" type="lines"
+              purge="False">
+      <element value="held_position"/>
+      <element value="organization"/>
+      <element value="person"/>
+      <element value="position"/>
+    </property>
+  </object>
+</object>

--- a/src/collective/contact/core/upgrades/upgrades.py
+++ b/src/collective/contact/core/upgrades/upgrades.py
@@ -67,3 +67,8 @@ def v7(context):
 def v8(context):
     tool = IUpgradeTool(context)
     tool.runProfile('collective.contact.core.upgrades:v8')
+
+
+def v9(context):
+    tool = IUpgradeTool(context)
+    tool.runProfile('collective.contact.core.upgrades:v9')


### PR DESCRIPTION
This PR hides contact types from the navigation, we think in the most cases you don't need em in the navigation.

Signed-off-by: Rene Jochum <rene@jochums.at>