### PR TITLE
Held position contact details behavior and person details privacy.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,15 +15,32 @@ First, create a directory in your site. This directory will contain all the info
 
 You can then add organizations to this directory. An organization can contain organizations (such as services, divisions or department) or positions (such as CEO, mayor or developer).
 
-You can also add persons to this directory. A person is a physical person that can hold one or more positions or be member of one or more organizations. To associate a person with an organization or a position, add a held position content type in the person's context.
+You can also add persons to this directory. A person is a physical person that can hold one or more positions or be member of one or more organizations.
+To associate a person with an organization or a position, add a held position content type in the person's context.
 
 Consider the following:
+
 * the person type will contain personal contact details
 * the held_position type will contain professional contact details
 
 Modify your directory to customize the organization types and the position types that you will associate with your organizations, sub-organizations and positions.
 
 Look at the test data profile collective.contact.core test data for detailed examples.
+
+
+Configuration
+=============
+
+The following configuration can be adapted in the plone registry (prefix=IContactCoreParameters):
+
+* person_contact_details_private : boolean, default to True.
+    The person contact details are private and will not be used in other context, like held position.
+* person_title_in_title : boolean, default to True.
+    Display person title in displayed person's title.
+* use_held_positions_to_search_person : boolean, default to True.
+    Use held positions to search persons.
+* use_description_to_search_person : boolean, default to True.
+    Use description to search persons.
 
 Localization
 ============

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,13 @@ How-to
 
 First, create a directory in your site. This directory will contain all the informations related to your contacts.
 
-You can then add organizations to his directory. An organization can contain organizations (such as services, divisions or department) or positions (such as CEO, mayor or developer).
+You can then add organizations to this directory. An organization can contain organizations (such as services, divisions or department) or positions (such as CEO, mayor or developer).
 
 You can also add persons to this directory. A person is a physical person that can hold one or more positions or be member of one or more organizations. To associate a person with an organization or a position, add a held position content type in the person's context.
+
+Consider the following:
+* the person type will contain personal contact details
+* the held_position type will contain professional contact details
 
 Modify your directory to customize the organization types and the position types that you will associate with your organizations, sub-organizations and positions.
 

--- a/src/collective/contact/core/adapters.py
+++ b/src/collective/contact/core/adapters.py
@@ -8,9 +8,8 @@ from Products.CMFPlone.utils import safe_unicode
 from plone import api
 
 from collective.contact.core.interfaces import IVCard, IContactable,\
-    IPersonHeldPositions
-from collective.contact.core.content.held_position import IHeldPosition,\
-                                                             HeldPosition
+    IPersonHeldPositions, IHeldPosition
+from collective.contact.core.content.held_position import HeldPosition
 from collective.contact.core.content.organization import IOrganization,\
                                                              Organization
 from collective.contact.core.behaviors import IBirthday

--- a/src/collective/contact/core/browser/addcontact.py
+++ b/src/collective/contact/core/browser/addcontact.py
@@ -186,7 +186,8 @@ $(document).ready(function() {
   } else {
     min_radio = 2;
   }
-  var position_fields = '#formfield-oform-widgets-position,div[id*=held_position]';
+  o.find('#formfield-oform-widgets-use_parent_address input').prop("checked", true);
+  var position_fields = '#formfield-oform-widgets-position,div[id*=held_position],#formfield-oform-widgets-email,#formfield-oform-widgets-phone,#formfield-oform-widgets-cell_phone,#formfield-oform-widgets-fax,#formfield-oform-widgets-website,#formfield-oform-widgets-im_handle,#formfield-oform-widgets-use_parent_address';
   if (!(o.find('input[name="oform.widgets.person"]').length >= min_radio &&
         o.find('input[name="oform.widgets.organization"]').length >= min_radio)) {
       o.find(position_fields).hide();
@@ -360,7 +361,6 @@ class AddContact(DefaultAddForm, form.AddForm):
                     # copy field to not modify original one
                     widget.field = copy.copy(widget.field)
                     widget.field.required = False
-
         if 'parent_address' in self.widgets:
             self.widgets['parent_address'].mode = DISPLAY_MODE
 

--- a/src/collective/contact/core/browser/addcontact.py
+++ b/src/collective/contact/core/browser/addcontact.py
@@ -1,3 +1,5 @@
+import copy
+
 from AccessControl import getSecurityManager
 from zope.component import getUtility, queryAdapter
 from zope.contentprovider.interfaces import IContentProvider
@@ -355,10 +357,8 @@ class AddContact(DefaultAddForm, form.AddForm):
         if self.schema != IAddHeldPosition:
             for widget in self.widgets.values():
                 if getattr(widget, 'required', False):
-                    # This is really a hack to not have required field errors
-                    # but have the visual required nevertheless.
-                    # We need to revert this after updateActions
-                    # because this change impact the held position form
+                    # copy field to not modify original one
+                    widget.field = copy.copy(widget.field)
                     widget.field.required = False
 
         if 'parent_address' in self.widgets:
@@ -366,11 +366,6 @@ class AddContact(DefaultAddForm, form.AddForm):
 
     def update(self):
         super(AddContact, self).update()
-        if self.schema != IAddHeldPosition:
-            # revert required field changes
-            for widget in self.widgets.values():
-                if getattr(widget, 'required', False):
-                    widget.field.required = True
 
     @button.buttonAndHandler(_('Add'), name='save')
     def handleAdd(self, action):

--- a/src/collective/contact/core/browser/address.py
+++ b/src/collective/contact/core/browser/address.py
@@ -1,11 +1,12 @@
 from Acquisition import aq_base
 
 from five import grok
+from plone import api
 
 from collective.contact.core.behaviors import IContactDetails
 from collective.contact.core.browser import TEMPLATES_DIR
 from collective.contact.core.behaviors import ADDRESS_FIELDS
-from collective.contact.core.interfaces import IHeldPosition
+from collective.contact.core.interfaces import IHeldPosition, IContactCoreParameters
 
 grok.templatedir(TEMPLATES_DIR)
 
@@ -14,7 +15,8 @@ def get_address(obj):
     """Returns a dictionary which contains address fields"""
     if aq_base(obj).use_parent_address is True:
         related = None
-        if IHeldPosition.providedBy(obj):
+        priv = api.portal.get_registry_record(name='person_contact_details_private', interface=IContactCoreParameters)
+        if IHeldPosition.providedBy(obj) and priv:
             # For a held position, we use the related element: a position or an organization
             related = (obj.get_position() or obj.get_organization())
         elif hasattr(obj, 'aq_parent'):

--- a/src/collective/contact/core/browser/basefields/views.py
+++ b/src/collective/contact/core/browser/basefields/views.py
@@ -10,7 +10,7 @@ from collective.contact.core.browser.utils import date_to_DateTime
 from collective.contact.core.content.person import IPerson
 from collective.contact.core.content.organization import IOrganization
 from collective.contact.core.content.position import IPosition
-from collective.contact.core.content.held_position import IHeldPosition
+from collective.contact.core.interfaces import IHeldPosition
 
 
 grok.templatedir('templates')

--- a/src/collective/contact/core/browser/configure.zcml
+++ b/src/collective/contact/core/browser/configure.zcml
@@ -14,7 +14,7 @@
 
   <browser:page
       name="view"
-      for="..content.held_position.IHeldPosition"
+      for="..interfaces.IHeldPosition"
       class=".contact.Contact"
       template="templates/contact.pt"
       permission="zope2.View"

--- a/src/collective/contact/core/browser/contactable.py
+++ b/src/collective/contact/core/browser/contactable.py
@@ -109,7 +109,7 @@ class Contactable(grok.Adapter):
         we use the one of the first object in this list which have this information
         """
         contactables = []
-        related_items = [self.context, self.held_position, self.person, self.position] + list(reversed(self.organizations))
+        related_items = [self.context, self.held_position, self.position] + list(reversed(self.organizations))
         for related_item in related_items:
             if related_item is not None \
                and IContactDetails.providedBy(related_item) \

--- a/src/collective/contact/core/browser/contactable.py
+++ b/src/collective/contact/core/browser/contactable.py
@@ -7,17 +7,17 @@ from Acquisition import aq_base
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
+from plone import api
 from plone.dexterity.browser.view import DefaultView
 from plone.dexterity.utils import getAdditionalSchemata
 
 from collective.contact.core.browser import TEMPLATES_DIR
 from collective.contact.core.browser.address import get_address
 from collective.contact.core.behaviors import IContactDetails
-from collective.contact.core.interfaces import IContactable
+from collective.contact.core.interfaces import IContactable, IContactCoreParameters
 from collective.contact.widget.interfaces import IContactContent
 from collective.contact.core.behaviors import CONTACT_DETAILS_FIELDS
 from collective.contact.core.browser.utils import get_valid_url
-
 
 grok.templatedir(TEMPLATES_DIR)
 
@@ -110,6 +110,8 @@ class Contactable(grok.Adapter):
         """
         contactables = []
         related_items = [self.context, self.held_position, self.position] + list(reversed(self.organizations))
+        if not api.portal.get_registry_record(name='person_contact_details_private', interface=IContactCoreParameters):
+            related_items.insert(2, self.person)
         for related_item in related_items:
             if related_item is not None \
                and IContactDetails.providedBy(related_item) \

--- a/src/collective/contact/core/browser/excelexport.py
+++ b/src/collective/contact/core/browser/excelexport.py
@@ -18,8 +18,7 @@ except ImportError:
     HAS_EXCELEXPORT = False
 
 from collective.contact.widget.interfaces import IContactChoice, IContactContent
-from collective.contact.core.content.held_position import IHeldPosition
-from collective.contact.core.interfaces import IContactable
+from collective.contact.core.interfaces import IContactable, IHeldPosition
 from collective.contact.core.behaviors import ADDRESS_FIELDS
 
 

--- a/src/collective/contact/core/configure.zcml
+++ b/src/collective/contact/core/configure.zcml
@@ -31,6 +31,7 @@
       title="collective.contact.core postInstall import step"
       description="Post install import step from collective.contact.core"
       handler=".setuphandlers.postInstall">
+      <depends name="plone.app.registry"/>
   </genericsetup:importStep>
 
   <genericsetup:importStep

--- a/src/collective/contact/core/content/held_position.py
+++ b/src/collective/contact/core/content/held_position.py
@@ -3,66 +3,19 @@ from Products.CMFPlone.utils import normalizeString, safe_unicode
 
 from z3c.form.interfaces import NO_VALUE
 from zope.interface import implements
-from zope import schema
 
 from five import grok
 
 from plone.dexterity.schema import DexteritySchemaPolicy
 from plone.dexterity.content import Container
-from plone.namedfile.field import NamedImage
-from plone.supermodel import model
 
-from collective.contact.core import _
-from collective.contact.core.schema import ContactChoice
 from collective.contact.core.browser.contactable import Contactable
-from collective.contact.widget.source import ContactSourceBinder
-from collective.contact.widget.interfaces import IContactContent
+from collective.contact.core.interfaces import IHeldPosition
 
 
 def acqproperty(func):
     """Property that manages acquisition"""
     return ComputedAttribute(func, 1)
-
-
-class IHeldPosition(model.Schema, IContactContent):
-    """Interface for HeldPosition content type"""
-
-    position = ContactChoice(
-        title=_("Organization/Position"),
-        source=ContactSourceBinder(portal_type=("organization", "position")),
-        required=True,
-    )
-    label = schema.TextLine(
-        title=_("Additional label"),
-        description=_("Additional label with information that does not appear "
-                      "on position label"),
-        required=False)
-    start_date = schema.Date(
-        title=_("Start date"),
-        required=False,
-    )
-    end_date = schema.Date(
-        title=_("End date"),
-        required=False,
-    )
-    photo = NamedImage(
-        title=_("Photo"),
-        required=False,
-        readonly=True,
-    )
-
-    def get_person(self):
-        """Returns the person who holds the position
-        """
-
-    def get_position(self):
-        """Returns the position (if position field is a position)
-        """
-
-    def get_organization(self):
-        """Returns the first organization related to HeldPosition
-        i.e. position field or parent of the position
-        """
 
 
 class HeldPositionContactableAdapter(Contactable):

--- a/src/collective/contact/core/content/organization.py
+++ b/src/collective/contact/core/content/organization.py
@@ -18,8 +18,9 @@ from plone.app.textfield import RichText
 
 from collective.contact.core import _, logger
 from collective.contact.core.browser.contactable import Contactable
+from collective.contact.core.interfaces import IHeldPosition
 from collective.contact.widget.interfaces import IContactContent
-from collective.contact.core.content.held_position import IHeldPosition
+
 
 class IOrganization(model.Schema, IContactContent):
     """Interface for Organization content type"""

--- a/src/collective/contact/core/content/person.py
+++ b/src/collective/contact/core/content/person.py
@@ -19,9 +19,8 @@ from plone.supermodel import model
 from collective.contact.core import _
 from collective.contact.core.browser.contactable import Contactable
 from collective.contact.core.interfaces import IContactCoreParameters,\
-    IPersonHeldPositions, IContactable
+    IPersonHeldPositions, IContactable, IHeldPosition
 from collective.contact.widget.interfaces import IContactContent
-from collective.contact.core.content.held_position import IHeldPosition
 
 
 class IPerson(model.Schema, IContactContent):

--- a/src/collective/contact/core/content/position.py
+++ b/src/collective/contact/core/content/position.py
@@ -14,7 +14,7 @@ from collective.contact.widget.interfaces import IContactContent
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 from zc.relation.interfaces import ICatalog
-from collective.contact.core.content.held_position import IHeldPosition
+from collective.contact.core.interfaces import IHeldPosition
 from collective.contact.core import logger
 
 

--- a/src/collective/contact/core/indexers.py
+++ b/src/collective/contact/core/indexers.py
@@ -1,14 +1,13 @@
 from datetime import date
 from plone import api
 from plone.indexer import indexer
-from Products.CMFPlone.utils import normalizeString
 from Products.CMFPlone.utils import safe_unicode
 
-from collective.contact.core.content.held_position import IHeldPosition
 from collective.contact.core.content.organization import IOrganization
 from collective.contact.core.content.position import IPosition
 from collective.contact.core.content.person import IPerson
 from collective.contact.core.behaviors import IRelatedOrganizations
+from collective.contact.core.interfaces import IHeldPosition
 
 
 @indexer(IOrganization)

--- a/src/collective/contact/core/interfaces.py
+++ b/src/collective/contact/core/interfaces.py
@@ -1,7 +1,13 @@
 from zope.interface import Interface
 from zope import schema
 
+from plone.namedfile.field import NamedImage
+from plone.supermodel import model
+
 from collective.contact.core import _
+from collective.contact.core.schema import ContactChoice
+from collective.contact.widget.interfaces import IContactContent
+from collective.contact.widget.source import ContactSourceBinder
 
 
 class IContactable(Interface):
@@ -62,4 +68,45 @@ class IPersonHeldPositions(Interface):
 
     def get_sorted_positions(self):
         """Get sorted positions
+        """
+
+
+class IHeldPosition(model.Schema, IContactContent):
+    """Interface for HeldPosition content type"""
+
+    position = ContactChoice(
+        title=_("Organization/Position"),
+        source=ContactSourceBinder(portal_type=("organization", "position")),
+        required=True,
+    )
+    label = schema.TextLine(
+        title=_("Additional label"),
+        description=_("Additional label with information that does not appear "
+                      "on position label"),
+        required=False)
+    start_date = schema.Date(
+        title=_("Start date"),
+        required=False,
+    )
+    end_date = schema.Date(
+        title=_("End date"),
+        required=False,
+    )
+    photo = NamedImage(
+        title=_("Photo"),
+        required=False,
+        readonly=True,
+    )
+
+    def get_person(self):
+        """Returns the person who holds the position
+        """
+
+    def get_position(self):
+        """Returns the position (if position field is a position)
+        """
+
+    def get_organization(self):
+        """Returns the first organization related to HeldPosition
+        i.e. position field or parent of the position
         """

--- a/src/collective/contact/core/interfaces.py
+++ b/src/collective/contact/core/interfaces.py
@@ -35,6 +35,11 @@ class IVCard(Interface):
 
 class IContactCoreParameters(Interface):
 
+    person_contact_details_private = schema.Bool(
+        title=_(u"The person contact details are private and will not be used in other context, like held position."),
+        description=u"",
+        required=False, default=True)
+
     person_title_in_title = schema.Bool(
         title=_(u"Display person title in displayed person's title."),
         description=u"",

--- a/src/collective/contact/core/locales/collective.contact.core.pot
+++ b/src/collective/contact/core/locales/collective.contact.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-30 13:55+0000\n"
+"POT-Creation-Date: 2017-04-26 06:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.contact.core\n"
 
-#: ../browser/addcontact.py:110
+#: ../browser/addcontact.py:112
 msgid "${name} (${position}"
 msgstr ""
 
-#: ../browser/addcontact.py:330
+#: ../browser/addcontact.py:333
 msgid "A contact is a position held by a person in an organization"
 msgstr ""
 
@@ -34,11 +34,11 @@ msgid "Active"
 msgstr ""
 
 #: ../browser/basefields/templates/organization.pt:23
-#: ../content/organization.py:28
+#: ../content/organization.py:29
 msgid "Activity"
 msgstr ""
 
-#: ../browser/addcontact.py:375
+#: ../browser/addcontact.py:370
 msgid "Add"
 msgstr ""
 
@@ -46,11 +46,11 @@ msgstr ""
 msgid "Additional address details"
 msgstr ""
 
-#: ../content/held_position.py:36
+#: ../interfaces.py:88
 msgid "Additional label"
 msgstr ""
 
-#: ../content/held_position.py:37
+#: ../interfaces.py:89
 msgid "Additional label with information that does not appear on position label"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: ../browser/addcontact.py:101
+#: ../browser/addcontact.py:103
 msgid "Contact"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: ../browser/addcontact.py:63
+#: ../browser/addcontact.py:65
 #: ../browser/templates/organization.pt:83
 #: ../browser/templates/position.pt:41
 msgid "Create ${name}"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Directory"
 msgstr ""
 
-#: ../interfaces.py:33
+#: ../interfaces.py:44
 msgid "Display person title in displayed person's title."
 msgstr ""
 
@@ -132,7 +132,7 @@ msgstr ""
 
 #: ../browser/basefields/templates/held_position.pt:29
 #: ../browser/templates/heldpositions.pt:47
-#: ../content/held_position.py:45
+#: ../interfaces.py:97
 msgid "End date"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Female"
 msgstr ""
 
-#: ../content/person.py:37
+#: ../content/person.py:36
 msgid "Firstname"
 msgstr ""
 
-#: ../content/person.py:41
+#: ../content/person.py:40
 msgid "Gender"
 msgstr ""
 
@@ -174,11 +174,11 @@ msgstr ""
 msgid "IM handle"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "Installs test data for the collective.contact.core package"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "Installs the collective.contact.core package"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Invalid phone"
 msgstr ""
 
-#: ../content/person.py:33
+#: ../content/person.py:32
 msgid "Lastname"
 msgstr ""
 
@@ -202,7 +202,7 @@ msgstr ""
 msgid "Latitude"
 msgstr ""
 
-#: ../content/organization.py:38
+#: ../content/organization.py:39
 msgid "Logo"
 msgstr ""
 
@@ -234,11 +234,11 @@ msgstr ""
 msgid "Migration profile for collective.contact.core to 9"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:22
+#: ../browser/person_title_mapping.py:24
 msgid "Mr"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:23
+#: ../browser/person_title_mapping.py:25
 msgid "Mrs"
 msgstr ""
 
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#: ../browser/addcontact.py:271
+#: ../browser/addcontact.py:274
 #: ../content/directory.py:37
 #: ../profiles/default/types/organization.xml
 msgid "Organization"
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Organization types"
 msgstr ""
 
-#: ../content/held_position.py:31
+#: ../interfaces.py:83
 msgid "Organization/Position"
 msgstr ""
 
@@ -298,13 +298,13 @@ msgstr ""
 msgid "Parent organizations"
 msgstr ""
 
-#: ../browser/addcontact.py:277
+#: ../browser/addcontact.py:280
 #: ../profiles/default/types/person.xml
 #: ../upgrades/profiles/v2/types/person.xml
 msgid "Person"
 msgstr ""
 
-#: ../content/person.py:47
+#: ../content/person.py:46
 msgid "Person title"
 msgstr ""
 
@@ -320,12 +320,12 @@ msgstr ""
 msgid "Phone number"
 msgstr ""
 
-#: ../content/held_position.py:49
-#: ../content/person.py:53
+#: ../content/person.py:52
+#: ../interfaces.py:101
 msgid "Photo"
 msgstr ""
 
-#: ../browser/addcontact.py:283
+#: ../browser/addcontact.py:286
 #: ../browser/basefields/templates/held_position.pt:15
 #: ../content/directory.py:30
 msgid "Position"
@@ -360,21 +360,21 @@ msgstr ""
 msgid "Search and attach organizations related to this one"
 msgstr ""
 
-#: ../browser/addcontact.py:273
+#: ../browser/addcontact.py:276
 msgid "Select the organization where the person holds the position"
 msgstr ""
 
-#: ../browser/addcontact.py:278
+#: ../browser/addcontact.py:281
 msgid "Select the person who holds the position"
 msgstr ""
 
-#: ../browser/addcontact.py:285
+#: ../browser/addcontact.py:288
 msgid "Select the position held by this person in the selected organization"
 msgstr ""
 
 #: ../browser/basefields/templates/held_position.pt:23
 #: ../browser/templates/heldpositions.pt:42
-#: ../content/held_position.py:41
+#: ../interfaces.py:93
 msgid "Start date"
 msgstr ""
 
@@ -386,6 +386,10 @@ msgstr ""
 msgid "Street"
 msgstr ""
 
+#: ../interfaces.py:39
+msgid "The person contact details are private and will not be used in other context, like held position."
+msgstr ""
+
 #: ../content/directory.py:22
 msgid "Token"
 msgstr ""
@@ -394,15 +398,15 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: ../content/organization.py:33
+#: ../content/organization.py:34
 msgid "Type or level"
 msgstr ""
 
-#: ../interfaces.py:43
+#: ../interfaces.py:54
 msgid "Use description to search persons."
 msgstr ""
 
-#: ../interfaces.py:38
+#: ../interfaces.py:49
 msgid "Use held positions to search persons."
 msgstr ""
 
@@ -428,11 +432,11 @@ msgstr ""
 msgid "address_line"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "collective.contact.core"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "collective.contact.core test data"
 msgstr ""
 
@@ -451,21 +455,21 @@ msgid "from"
 msgstr ""
 
 #. Default: "Please fill the organization first and then eventually select position"
-#: ../browser/addcontact.py:474
+#: ../browser/addcontact.py:469
 msgid "help_add_organization_or_position_organization"
 msgstr ""
 
 #. Default: "Doctor, Mrs..."
-#: ../content/person.py:48
+#: ../content/person.py:47
 msgid "help_person_title"
 msgstr ""
 
 #. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../browser/addcontact.py:67
+#: ../browser/addcontact.py:69
 msgid "help_widget_add_new_elt"
 msgstr ""
 
-#: ../browser/addcontact.py:140
+#: ../browser/addcontact.py:142
 msgid "organization/position"
 msgstr ""
 

--- a/src/collective/contact/core/locales/de/LC_MESSAGES/collective.contact.core.po
+++ b/src/collective/contact/core/locales/de/LC_MESSAGES/collective.contact.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.contact.core\n"
-"POT-Creation-Date: 2017-03-30 13:55+0000\n"
+"POT-Creation-Date: 2017-04-26 06:48+0000\n"
 "PO-Revision-Date: 2016-11-16 11:24+0100\n"
 "Last-Translator: Cédric Messiant <cedric.messiant@gmail.com>\n"
 "Language-Team: French\n"
@@ -16,11 +16,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.8\n"
 "Language: de\n"
 
-#: ../browser/addcontact.py:110
+#: ../browser/addcontact.py:112
 msgid "${name} (${position}"
 msgstr "${name} (${position}"
 
-#: ../browser/addcontact.py:330
+#: ../browser/addcontact.py:333
 msgid "A contact is a position held by a person in an organization"
 msgstr "Ein Kontakt ist eine Position, die eine Person in einer Organisation hat"
 
@@ -33,11 +33,11 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: ../browser/basefields/templates/organization.pt:23
-#: ../content/organization.py:28
+#: ../content/organization.py:29
 msgid "Activity"
 msgstr "Aktivität"
 
-#: ../browser/addcontact.py:375
+#: ../browser/addcontact.py:370
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -45,11 +45,11 @@ msgstr "Hinzufügen"
 msgid "Additional address details"
 msgstr "Zusätzliche Details Adresse"
 
-#: ../content/held_position.py:36
+#: ../interfaces.py:88
 msgid "Additional label"
 msgstr "Zusätzliches Feld"
 
-#: ../content/held_position.py:37
+#: ../interfaces.py:89
 msgid "Additional label with information that does not appear on position label"
 msgstr "Zusätzliches Feld mit Information die nicht im Positionsfeld aufscheint"
 
@@ -76,7 +76,7 @@ msgstr "Mobil"
 msgid "City"
 msgstr "Stadt"
 
-#: ../browser/addcontact.py:101
+#: ../browser/addcontact.py:103
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Country"
 msgstr "Land"
 
-#: ../browser/addcontact.py:63
+#: ../browser/addcontact.py:65
 #: ../browser/templates/organization.pt:83
 #: ../browser/templates/position.pt:41
 msgid "Create ${name}"
@@ -116,7 +116,7 @@ msgstr "Deaktiviert"
 msgid "Directory"
 msgstr "Verzeichnis"
 
-#: ../interfaces.py:33
+#: ../interfaces.py:44
 msgid "Display person title in displayed person's title."
 msgstr "Akademischen Titel bei Person anzeigen"
 
@@ -131,7 +131,7 @@ msgstr "Email"
 
 #: ../browser/basefields/templates/held_position.pt:29
 #: ../browser/templates/heldpositions.pt:47
-#: ../content/held_position.py:45
+#: ../interfaces.py:97
 msgid "End date"
 msgstr "Enddatum"
 
@@ -147,11 +147,11 @@ msgstr "Fax"
 msgid "Female"
 msgstr "Weiblich"
 
-#: ../content/person.py:37
+#: ../content/person.py:36
 msgid "Firstname"
 msgstr "Vorname"
 
-#: ../content/person.py:41
+#: ../content/person.py:40
 msgid "Gender"
 msgstr "Geschlecht"
 
@@ -173,11 +173,11 @@ msgstr "Position"
 msgid "IM handle"
 msgstr "IM Benutzername"
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "Installs test data for the collective.contact.core package"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "Installs the collective.contact.core package"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgstr "Ungültige E-Mail Adresse"
 msgid "Invalid phone"
 msgstr "Ungültige Telefonnummer"
 
-#: ../content/person.py:33
+#: ../content/person.py:32
 msgid "Lastname"
 msgstr "Nachname"
 
@@ -201,7 +201,7 @@ msgstr "Nachname"
 msgid "Latitude"
 msgstr "Latitude"
 
-#: ../content/organization.py:38
+#: ../content/organization.py:39
 msgid "Logo"
 msgstr "Logo"
 
@@ -233,11 +233,11 @@ msgstr ""
 msgid "Migration profile for collective.contact.core to 9"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:22
+#: ../browser/person_title_mapping.py:24
 msgid "Mr"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:23
+#: ../browser/person_title_mapping.py:25
 msgid "Mrs"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr "Nicht zugewiesen"
 msgid "Number"
 msgstr "Nummer"
 
-#: ../browser/addcontact.py:271
+#: ../browser/addcontact.py:274
 #: ../content/directory.py:37
 #: ../profiles/default/types/organization.xml
 msgid "Organization"
@@ -275,7 +275,7 @@ msgstr "Organisationstyp"
 msgid "Organization types"
 msgstr "Organisationstypen"
 
-#: ../content/held_position.py:31
+#: ../interfaces.py:83
 msgid "Organization/Position"
 msgstr "Organisation/Position"
 
@@ -297,13 +297,13 @@ msgstr "Weitere Kontakte in dieser Organisation"
 msgid "Parent organizations"
 msgstr "Übergeordnete Organisationen"
 
-#: ../browser/addcontact.py:277
+#: ../browser/addcontact.py:280
 #: ../profiles/default/types/person.xml
 #: ../upgrades/profiles/v2/types/person.xml
 msgid "Person"
 msgstr "Person"
 
-#: ../content/person.py:47
+#: ../content/person.py:46
 msgid "Person title"
 msgstr "Person-Titel"
 
@@ -319,12 +319,12 @@ msgstr "Telefon"
 msgid "Phone number"
 msgstr "Telefon"
 
-#: ../content/held_position.py:49
-#: ../content/person.py:53
+#: ../content/person.py:52
+#: ../interfaces.py:101
 msgid "Photo"
 msgstr "Foto"
 
-#: ../browser/addcontact.py:283
+#: ../browser/addcontact.py:286
 #: ../browser/basefields/templates/held_position.pt:15
 #: ../content/directory.py:30
 msgid "Position"
@@ -359,21 +359,21 @@ msgstr "Verwandte Organisationen"
 msgid "Search and attach organizations related to this one"
 msgstr "Suchen und Hinzufügen verwandter Organisationen"
 
-#: ../browser/addcontact.py:273
+#: ../browser/addcontact.py:276
 msgid "Select the organization where the person holds the position"
 msgstr "Organisation wählen in der die Person die Position hat"
 
-#: ../browser/addcontact.py:278
+#: ../browser/addcontact.py:281
 msgid "Select the person who holds the position"
 msgstr "Wähle die Person, die die Position hat"
 
-#: ../browser/addcontact.py:285
+#: ../browser/addcontact.py:288
 msgid "Select the position held by this person in the selected organization"
 msgstr "Wähle die Position, die die Person in der gewählten Organisation hat"
 
 #: ../browser/basefields/templates/held_position.pt:23
 #: ../browser/templates/heldpositions.pt:42
-#: ../content/held_position.py:41
+#: ../interfaces.py:93
 msgid "Start date"
 msgstr "Beginndatum"
 
@@ -385,6 +385,10 @@ msgstr ""
 msgid "Street"
 msgstr "Straße"
 
+#: ../interfaces.py:39
+msgid "The person contact details are private and will not be used in other context, like held position."
+msgstr ""
+
 #: ../content/directory.py:22
 msgid "Token"
 msgstr "Token"
@@ -393,15 +397,15 @@ msgstr "Token"
 msgid "Type"
 msgstr "Typ"
 
-#: ../content/organization.py:33
+#: ../content/organization.py:34
 msgid "Type or level"
 msgstr "Typen oder Ebenen"
 
-#: ../interfaces.py:43
+#: ../interfaces.py:54
 msgid "Use description to search persons."
 msgstr "Verwende Beschreibung zum Suchen von Personen"
 
-#: ../interfaces.py:38
+#: ../interfaces.py:49
 msgid "Use held positions to search persons."
 msgstr "Verwende Positionen zum Suchen von Personen"
 
@@ -427,11 +431,11 @@ msgstr "Postleitzahl"
 msgid "address_line"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "collective.contact.core"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "collective.contact.core test data"
 msgstr ""
 
@@ -450,21 +454,21 @@ msgid "from"
 msgstr "von"
 
 #. Default: "Please fill the organization first and then eventually select position"
-#: ../browser/addcontact.py:474
+#: ../browser/addcontact.py:469
 msgid "help_add_organization_or_position_organization"
 msgstr "Bitte erst Organisation eingeben und dann eventuell Position auswählen"
 
 #. Default: "Doctor, Mrs..."
-#: ../content/person.py:48
+#: ../content/person.py:47
 msgid "help_person_title"
 msgstr "\"Dr, Frau...\""
 
 #. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../browser/addcontact.py:67
+#: ../browser/addcontact.py:69
 msgid "help_widget_add_new_elt"
 msgstr "Wenn das Element nicht vorhanden ist, kann es zur Datenbank hinzugefügt werden:"
 
-#: ../browser/addcontact.py:140
+#: ../browser/addcontact.py:142
 msgid "organization/position"
 msgstr "Organisation/Position"
 

--- a/src/collective/contact/core/locales/fr/LC_MESSAGES/collective.contact.core.po
+++ b/src/collective/contact/core/locales/fr/LC_MESSAGES/collective.contact.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.contact.core\n"
-"POT-Creation-Date: 2017-03-30 13:55+0000\n"
+"POT-Creation-Date: 2017-04-26 06:48+0000\n"
 "PO-Revision-Date: 2017-03-30 15:56+0200\n"
 "Last-Translator: Harald Friessnegger <harald@webmeisterei.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Language: fr\n"
 
-#: ../browser/addcontact.py:110
+#: ../browser/addcontact.py:112
 msgid "${name} (${position}"
 msgstr ""
 
-#: ../browser/addcontact.py:330
+#: ../browser/addcontact.py:333
 msgid "A contact is a position held by a person in an organization"
 msgstr "Un contact est une fonction occupée par une personne dans une organisation"
 
@@ -34,11 +34,11 @@ msgid "Active"
 msgstr "Actif"
 
 #: ../browser/basefields/templates/organization.pt:23
-#: ../content/organization.py:28
+#: ../content/organization.py:29
 msgid "Activity"
 msgstr "Activité"
 
-#: ../browser/addcontact.py:375
+#: ../browser/addcontact.py:370
 msgid "Add"
 msgstr "Ajouter"
 
@@ -46,19 +46,21 @@ msgstr "Ajouter"
 msgid "Additional address details"
 msgstr "Complément d'adresse"
 
-#: ../content/held_position.py:36
+#: ../interfaces.py:88
 msgid "Additional label"
 msgstr "Intitulé"
 
-#: ../content/held_position.py:37
+#: ../interfaces.py:89
 msgid "Additional label with information that does not appear on position label"
 msgstr "Intitulé complétant l'intitulé de poste"
 
-#: ../behaviors.py:138 ../browser/templates/address.pt:6
+#: ../behaviors.py:138
+#: ../browser/templates/address.pt:6
 msgid "Address"
 msgstr "Adresse "
 
-#: ../behaviors.py:327 ../behaviors.zcml:28
+#: ../behaviors.py:327
+#: ../behaviors.zcml:28
 #: ../browser/basefields/templates/person.pt:27
 msgid "Birthday"
 msgstr "Date de naissance "
@@ -75,11 +77,12 @@ msgstr "Numéro de téléphone portable "
 msgid "City"
 msgstr "Ville"
 
-#: ../browser/addcontact.py:101
+#: ../browser/addcontact.py:103
 msgid "Contact"
 msgstr "Contact"
 
-#: ../behaviors.py:133 ../behaviors.zcml:16
+#: ../behaviors.py:133
+#: ../behaviors.zcml:16
 msgid "Contact details"
 msgstr "Coordonnées"
 
@@ -95,7 +98,8 @@ msgstr ""
 msgid "Country"
 msgstr "Pays"
 
-#: ../browser/addcontact.py:63 ../browser/templates/organization.pt:83
+#: ../browser/addcontact.py:65
+#: ../browser/templates/organization.pt:83
 #: ../browser/templates/position.pt:41
 msgid "Create ${name}"
 msgstr "Créer ${name}"
@@ -113,7 +117,7 @@ msgstr "Désactivé"
 msgid "Directory"
 msgstr "Annuaire"
 
-#: ../interfaces.py:33
+#: ../interfaces.py:44
 msgid "Display person title in displayed person's title."
 msgstr "Afficher la civilité sur le titre de la personne."
 
@@ -121,12 +125,14 @@ msgstr "Afficher la civilité sur le titre de la personne."
 msgid "Download VCard"
 msgstr "Télécharger la VCard"
 
-#: ../behaviors.py:144 ../browser/templates/contactdetails.pt:11
+#: ../behaviors.py:144
+#: ../browser/templates/contactdetails.pt:11
 msgid "Email"
 msgstr "Courriel "
 
 #: ../browser/basefields/templates/held_position.pt:29
-#: ../browser/templates/heldpositions.pt:47 ../content/held_position.py:45
+#: ../browser/templates/heldpositions.pt:47
+#: ../interfaces.py:97
 msgid "End date"
 msgstr "Date de fin "
 
@@ -142,15 +148,16 @@ msgstr "Numéro de fax "
 msgid "Female"
 msgstr "Féminin"
 
-#: ../content/person.py:37
+#: ../content/person.py:36
 msgid "Firstname"
 msgstr "Prénom"
 
-#: ../content/person.py:41
+#: ../content/person.py:40
 msgid "Gender"
 msgstr "Genre"
 
-#: ../behaviors.py:77 ../behaviors.zcml:22
+#: ../behaviors.py:77
+#: ../behaviors.zcml:22
 msgid "Global positioning"
 msgstr "Localisation"
 
@@ -167,11 +174,11 @@ msgstr "Fonction occupée"
 msgid "IM handle"
 msgstr "Identifiant de messagerie instantanée "
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "Installs test data for the collective.contact.core package"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "Installs the collective.contact.core package"
 msgstr ""
 
@@ -187,7 +194,7 @@ msgstr "Adresse électronique invalide"
 msgid "Invalid phone"
 msgstr "Numéro de téléphone invalide"
 
-#: ../content/person.py:33
+#: ../content/person.py:32
 msgid "Lastname"
 msgstr "Nom de famille"
 
@@ -195,7 +202,7 @@ msgstr "Nom de famille"
 msgid "Latitude"
 msgstr "Latitude"
 
-#: ../content/organization.py:38
+#: ../content/organization.py:39
 msgid "Logo"
 msgstr "Logo"
 
@@ -227,11 +234,11 @@ msgstr ""
 msgid "Migration profile for collective.contact.core to 9"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:22
+#: ../browser/person_title_mapping.py:24
 msgid "Mr"
 msgstr "Monsieur"
 
-#: ../browser/person_title_mapping.py:23
+#: ../browser/person_title_mapping.py:25
 msgid "Mrs"
 msgstr "Madame"
 
@@ -247,7 +254,8 @@ msgstr "Non assigné"
 msgid "Number"
 msgstr "Numéro"
 
-#: ../browser/addcontact.py:271 ../content/directory.py:37
+#: ../browser/addcontact.py:274
+#: ../content/directory.py:37
 #: ../profiles/default/types/organization.xml
 msgid "Organization"
 msgstr "Organisation"
@@ -268,11 +276,12 @@ msgstr "Type d'organisation "
 msgid "Organization types"
 msgstr "Types d'organisations"
 
-#: ../content/held_position.py:31
+#: ../interfaces.py:83
 msgid "Organization/Position"
 msgstr "Organisation/Fonction"
 
-#: ../browser/templates/contact.pt:17 ../browser/templates/directory.pt:19
+#: ../browser/templates/contact.pt:17
+#: ../browser/templates/directory.pt:19
 msgid "Organizations"
 msgstr "Organisations "
 
@@ -284,16 +293,18 @@ msgstr "Organisations dans cette organisation "
 msgid "Other contacts in this organization:"
 msgstr "Autres contacts dans cette organisation :"
 
-#: ../browser/templates/organization.pt:19 ../browser/templates/position.pt:17
+#: ../browser/templates/organization.pt:19
+#: ../browser/templates/position.pt:17
 msgid "Parent organizations"
 msgstr "Organisations parentes "
 
-#: ../browser/addcontact.py:277 ../profiles/default/types/person.xml
+#: ../browser/addcontact.py:280
+#: ../profiles/default/types/person.xml
 #: ../upgrades/profiles/v2/types/person.xml
 msgid "Person"
 msgstr "Personne"
 
-#: ../content/person.py:47
+#: ../content/person.py:46
 msgid "Person title"
 msgstr "Civilité"
 
@@ -309,11 +320,12 @@ msgstr "Téléphone"
 msgid "Phone number"
 msgstr "Numéro de téléphone "
 
-#: ../content/held_position.py:49 ../content/person.py:53
+#: ../content/person.py:52
+#: ../interfaces.py:101
 msgid "Photo"
 msgstr "Photo"
 
-#: ../browser/addcontact.py:283
+#: ../browser/addcontact.py:286
 #: ../browser/basefields/templates/held_position.pt:15
 #: ../content/directory.py:30
 msgid "Position"
@@ -339,7 +351,8 @@ msgstr "Fonctions dans cette organisation "
 msgid "Region"
 msgstr "Région"
 
-#: ../behaviors.py:340 ../behaviors.zcml:34
+#: ../behaviors.py:340
+#: ../behaviors.zcml:34
 msgid "Related organizations"
 msgstr "Organisations rattachées"
 
@@ -347,20 +360,21 @@ msgstr "Organisations rattachées"
 msgid "Search and attach organizations related to this one"
 msgstr "Recherchez et associez les organisations liées à cette organisation."
 
-#: ../browser/addcontact.py:273
+#: ../browser/addcontact.py:276
 msgid "Select the organization where the person holds the position"
 msgstr "Sélectionnez l'organisation où la personne occupe la fonction"
 
-#: ../browser/addcontact.py:278
+#: ../browser/addcontact.py:281
 msgid "Select the person who holds the position"
 msgstr "Sélectionnez la personne qui occupe cette fonction"
 
-#: ../browser/addcontact.py:285
+#: ../browser/addcontact.py:288
 msgid "Select the position held by this person in the selected organization"
 msgstr "Sélectionnez la fonction occupée par cette personne dans l'organisation sélectionnée"
 
 #: ../browser/basefields/templates/held_position.pt:23
-#: ../browser/templates/heldpositions.pt:42 ../content/held_position.py:41
+#: ../browser/templates/heldpositions.pt:42
+#: ../interfaces.py:93
 msgid "Start date"
 msgstr "Date de début "
 
@@ -372,6 +386,10 @@ msgstr ""
 msgid "Street"
 msgstr "Rue"
 
+#: ../interfaces.py:39
+msgid "The person contact details are private and will not be used in other context, like held position."
+msgstr "Les données de contact d'une personne sont privées et ne sont pas utilisées dans un autre contexte, tel qu'une fonction occupée."
+
 #: ../content/directory.py:22
 msgid "Token"
 msgstr "Identifiant"
@@ -380,15 +398,15 @@ msgstr "Identifiant"
 msgid "Type"
 msgstr "Type"
 
-#: ../content/organization.py:33
+#: ../content/organization.py:34
 msgid "Type or level"
 msgstr "Type ou niveau"
 
-#: ../interfaces.py:43
+#: ../interfaces.py:54
 msgid "Use description to search persons."
 msgstr "Utiliser la description pour rechercher des personnes."
 
-#: ../interfaces.py:38
+#: ../interfaces.py:49
 msgid "Use held positions to search persons."
 msgstr "Utiliser la position occupée pour rechercher des personnes."
 
@@ -400,7 +418,8 @@ msgstr "Utiliser l'adresse de l'entité d'appartenance"
 msgid "We can attach organizations on content."
 msgstr ""
 
-#: ../behaviors.py:166 ../browser/templates/contactdetails.pt:50
+#: ../behaviors.py:166
+#: ../browser/templates/contactdetails.pt:50
 msgid "Website"
 msgstr "Site web "
 
@@ -413,11 +432,11 @@ msgstr "Code postal"
 msgid "address_line"
 msgstr "${street} ${number}"
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "collective.contact.core"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "collective.contact.core test data"
 msgstr ""
 
@@ -436,21 +455,21 @@ msgid "from"
 msgstr "de"
 
 #. Default: "Please fill the organization first and then eventually select position"
-#: ../browser/addcontact.py:474
+#: ../browser/addcontact.py:469
 msgid "help_add_organization_or_position_organization"
 msgstr "Veuillez commencer par sélectionner l'organisation, pour sélectionner ensuite la fonction éventuelle."
 
 #. Default: "Doctor, Mrs..."
-#: ../content/person.py:48
+#: ../content/person.py:47
 msgid "help_person_title"
 msgstr "Docteur, Mme..."
 
 #. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../browser/addcontact.py:67
+#: ../browser/addcontact.py:69
 msgid "help_widget_add_new_elt"
 msgstr "Si l'élément n'existe pas, vous pouvez l'ajouter à la base :"
 
-#: ../browser/addcontact.py:140
+#: ../browser/addcontact.py:142
 msgid "organization/position"
 msgstr "organisation/fonction"
 

--- a/src/collective/contact/core/locales/it/LC_MESSAGES/collective.contact.core.po
+++ b/src/collective/contact/core/locales/it/LC_MESSAGES/collective.contact.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2017-03-30 13:55+0000\n"
+"POT-Creation-Date: 2017-04-26 06:48+0000\n"
 "PO-Revision-Date: 2016-10-04 18:45+0200\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: \n"
@@ -19,11 +19,11 @@ msgstr ""
 "Language: it\n"
 "X-Generator: Poedit 1.8.9\n"
 
-#: ../browser/addcontact.py:110
+#: ../browser/addcontact.py:112
 msgid "${name} (${position}"
 msgstr "${name} (${position}"
 
-#: ../browser/addcontact.py:330
+#: ../browser/addcontact.py:333
 msgid "A contact is a position held by a person in an organization"
 msgstr "Un contatto è una posizione tenuta da una persona in una organizzazione"
 
@@ -36,11 +36,11 @@ msgid "Active"
 msgstr "Attivo"
 
 #: ../browser/basefields/templates/organization.pt:23
-#: ../content/organization.py:28
+#: ../content/organization.py:29
 msgid "Activity"
 msgstr "Attività"
 
-#: ../browser/addcontact.py:375
+#: ../browser/addcontact.py:370
 msgid "Add"
 msgstr "Aggiungi"
 
@@ -48,11 +48,11 @@ msgstr "Aggiungi"
 msgid "Additional address details"
 msgstr "Dettagli aggiuntivi dell'indirizzo"
 
-#: ../content/held_position.py:36
+#: ../interfaces.py:88
 msgid "Additional label"
 msgstr "Etichetta aggiuntiva"
 
-#: ../content/held_position.py:37
+#: ../interfaces.py:89
 msgid "Additional label with information that does not appear on position label"
 msgstr "Etichetta aggiuntiva con informazioni che non compaiono nell'etichetta della posizione"
 
@@ -79,7 +79,7 @@ msgstr "Telefono cellulare"
 msgid "City"
 msgstr "Città"
 
-#: ../browser/addcontact.py:101
+#: ../browser/addcontact.py:103
 msgid "Contact"
 msgstr "Contatto"
 
@@ -100,7 +100,7 @@ msgstr ""
 msgid "Country"
 msgstr "Paese"
 
-#: ../browser/addcontact.py:63
+#: ../browser/addcontact.py:65
 #: ../browser/templates/organization.pt:83
 #: ../browser/templates/position.pt:41
 msgid "Create ${name}"
@@ -119,7 +119,7 @@ msgstr "Disattivato"
 msgid "Directory"
 msgstr "Directory"
 
-#: ../interfaces.py:33
+#: ../interfaces.py:44
 msgid "Display person title in displayed person's title."
 msgstr "Visualizza il titolo della persona nel titolo della persona visualizzata "
 
@@ -134,7 +134,7 @@ msgstr "E-mail"
 
 #: ../browser/basefields/templates/held_position.pt:29
 #: ../browser/templates/heldpositions.pt:47
-#: ../content/held_position.py:45
+#: ../interfaces.py:97
 msgid "End date"
 msgstr "Data fine"
 
@@ -150,11 +150,11 @@ msgstr "Numero di Fax"
 msgid "Female"
 msgstr "Donna"
 
-#: ../content/person.py:37
+#: ../content/person.py:36
 msgid "Firstname"
 msgstr "Nome"
 
-#: ../content/person.py:41
+#: ../content/person.py:40
 msgid "Gender"
 msgstr "Sesso"
 
@@ -176,11 +176,11 @@ msgstr "Posizione tenuta"
 msgid "IM handle"
 msgstr "Instant messaging"
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "Installs test data for the collective.contact.core package"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "Installs the collective.contact.core package"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr "Indirizzo e-mail invalido"
 msgid "Invalid phone"
 msgstr "Telefono invalido"
 
-#: ../content/person.py:33
+#: ../content/person.py:32
 msgid "Lastname"
 msgstr "Cognome"
 
@@ -204,7 +204,7 @@ msgstr "Cognome"
 msgid "Latitude"
 msgstr "Latitudine"
 
-#: ../content/organization.py:38
+#: ../content/organization.py:39
 msgid "Logo"
 msgstr "Logo"
 
@@ -236,11 +236,11 @@ msgstr ""
 msgid "Migration profile for collective.contact.core to 9"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:22
+#: ../browser/person_title_mapping.py:24
 msgid "Mr"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:23
+#: ../browser/person_title_mapping.py:25
 msgid "Mrs"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr "Non assegnata"
 msgid "Number"
 msgstr "Numero"
 
-#: ../browser/addcontact.py:271
+#: ../browser/addcontact.py:274
 #: ../content/directory.py:37
 #: ../profiles/default/types/organization.xml
 msgid "Organization"
@@ -278,7 +278,7 @@ msgstr "Tipo organizzazione"
 msgid "Organization types"
 msgstr "Tipi di organizzazione"
 
-#: ../content/held_position.py:31
+#: ../interfaces.py:83
 msgid "Organization/Position"
 msgstr "Organizzazione/Posizione"
 
@@ -300,13 +300,13 @@ msgstr "Altri contatti in questa organizzazione:"
 msgid "Parent organizations"
 msgstr "Organizzazione padre"
 
-#: ../browser/addcontact.py:277
+#: ../browser/addcontact.py:280
 #: ../profiles/default/types/person.xml
 #: ../upgrades/profiles/v2/types/person.xml
 msgid "Person"
 msgstr "Persona"
 
-#: ../content/person.py:47
+#: ../content/person.py:46
 msgid "Person title"
 msgstr "Titolo della persona"
 
@@ -322,12 +322,12 @@ msgstr "Telefono"
 msgid "Phone number"
 msgstr "Numero di telefono"
 
-#: ../content/held_position.py:49
-#: ../content/person.py:53
+#: ../content/person.py:52
+#: ../interfaces.py:101
 msgid "Photo"
 msgstr "Foto"
 
-#: ../browser/addcontact.py:283
+#: ../browser/addcontact.py:286
 #: ../browser/basefields/templates/held_position.pt:15
 #: ../content/directory.py:30
 msgid "Position"
@@ -362,21 +362,21 @@ msgstr "Organizzazioni correlate"
 msgid "Search and attach organizations related to this one"
 msgstr "Cerca e collega organizzazione collegate a questa"
 
-#: ../browser/addcontact.py:273
+#: ../browser/addcontact.py:276
 msgid "Select the organization where the person holds the position"
 msgstr "Seleziona l'organizzazione dove la persona mantiene la posizione"
 
-#: ../browser/addcontact.py:278
+#: ../browser/addcontact.py:281
 msgid "Select the person who holds the position"
 msgstr "Seleziona la persona che mantiene la posizione"
 
-#: ../browser/addcontact.py:285
+#: ../browser/addcontact.py:288
 msgid "Select the position held by this person in the selected organization"
 msgstr "Seleziona la posizione tenuta da questa persona nell'organizzazione selezionata"
 
 #: ../browser/basefields/templates/held_position.pt:23
 #: ../browser/templates/heldpositions.pt:42
-#: ../content/held_position.py:41
+#: ../interfaces.py:93
 msgid "Start date"
 msgstr "Datas inizio"
 
@@ -388,6 +388,10 @@ msgstr ""
 msgid "Street"
 msgstr "Vita"
 
+#: ../interfaces.py:39
+msgid "The person contact details are private and will not be used in other context, like held position."
+msgstr ""
+
 #: ../content/directory.py:22
 msgid "Token"
 msgstr "Token"
@@ -396,15 +400,15 @@ msgstr "Token"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../content/organization.py:33
+#: ../content/organization.py:34
 msgid "Type or level"
 msgstr "Tipo o livello"
 
-#: ../interfaces.py:43
+#: ../interfaces.py:54
 msgid "Use description to search persons."
 msgstr "Usa una descrizione per cercare le persone."
 
-#: ../interfaces.py:38
+#: ../interfaces.py:49
 msgid "Use held positions to search persons."
 msgstr "Usa le posizioni ricoperte per cercare le persone."
 
@@ -430,11 +434,11 @@ msgstr "CAP"
 msgid "address_line"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "collective.contact.core"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "collective.contact.core test data"
 msgstr ""
 
@@ -453,21 +457,21 @@ msgid "from"
 msgstr "Da"
 
 #. Default: "Please fill the organization first and then eventually select position"
-#: ../browser/addcontact.py:474
+#: ../browser/addcontact.py:469
 msgid "help_add_organization_or_position_organization"
 msgstr "Prego compila prima l'organizzazione poi eventualmente seleziona una posizione"
 
 #. Default: "Doctor, Mrs..."
-#: ../content/person.py:48
+#: ../content/person.py:47
 msgid "help_person_title"
 msgstr "Dottor, Sig.ra"
 
 #. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../browser/addcontact.py:67
+#: ../browser/addcontact.py:69
 msgid "help_widget_add_new_elt"
 msgstr "Se la voce non esiste, puoi aggiungerla al database:"
 
-#: ../browser/addcontact.py:140
+#: ../browser/addcontact.py:142
 msgid "organization/position"
 msgstr "organizzazione/posizione"
 

--- a/src/collective/contact/core/locales/sl/LC_MESSAGES/collective.contact.core.po
+++ b/src/collective/contact/core/locales/sl/LC_MESSAGES/collective.contact.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.contact.core\n"
-"POT-Creation-Date: 2017-03-30 13:55+0000\n"
+"POT-Creation-Date: 2017-04-26 06:48+0000\n"
 "PO-Revision-Date: 2016-10-01 22:38+0200\n"
 "Last-Translator: Cédric Messiant <cedric.messiant@gmail.com>\n"
 "Language-Team: French\n"
@@ -16,11 +16,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.8\n"
 "Language: sl\n"
 
-#: ../browser/addcontact.py:110
+#: ../browser/addcontact.py:112
 msgid "${name} (${position}"
 msgstr "${name} (${position}"
 
-#: ../browser/addcontact.py:330
+#: ../browser/addcontact.py:333
 msgid "A contact is a position held by a person in an organization"
 msgstr "Kontakt pomeni pozicijo, ki jo ima oseba v organizaciji"
 
@@ -33,11 +33,11 @@ msgid "Active"
 msgstr "akitven"
 
 #: ../browser/basefields/templates/organization.pt:23
-#: ../content/organization.py:28
+#: ../content/organization.py:29
 msgid "Activity"
 msgstr "Aktivnost"
 
-#: ../browser/addcontact.py:375
+#: ../browser/addcontact.py:370
 msgid "Add"
 msgstr "Dodaj"
 
@@ -45,11 +45,11 @@ msgstr "Dodaj"
 msgid "Additional address details"
 msgstr "Podatki o dodatnem naslovu"
 
-#: ../content/held_position.py:36
+#: ../interfaces.py:88
 msgid "Additional label"
 msgstr "Dodatna oznaka"
 
-#: ../content/held_position.py:37
+#: ../interfaces.py:89
 msgid "Additional label with information that does not appear on position label"
 msgstr "Dodatna oznaka z informacijami, ki niso vidne na oznaki pozicije"
 
@@ -76,7 +76,7 @@ msgstr "GSM Številka"
 msgid "City"
 msgstr "Mesto"
 
-#: ../browser/addcontact.py:101
+#: ../browser/addcontact.py:103
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Country"
 msgstr "Država"
 
-#: ../browser/addcontact.py:63
+#: ../browser/addcontact.py:65
 #: ../browser/templates/organization.pt:83
 #: ../browser/templates/position.pt:41
 msgid "Create ${name}"
@@ -116,7 +116,7 @@ msgstr "Deaktiviran"
 msgid "Directory"
 msgstr "Imenik"
 
-#: ../interfaces.py:33
+#: ../interfaces.py:44
 msgid "Display person title in displayed person's title."
 msgstr "Pokaži naziv osebe v prikazanem nazivu osebe"
 
@@ -131,7 +131,7 @@ msgstr "Email"
 
 #: ../browser/basefields/templates/held_position.pt:29
 #: ../browser/templates/heldpositions.pt:47
-#: ../content/held_position.py:45
+#: ../interfaces.py:97
 msgid "End date"
 msgstr "Končni datum"
 
@@ -147,11 +147,11 @@ msgstr "Telefaks številka"
 msgid "Female"
 msgstr "ženski"
 
-#: ../content/person.py:37
+#: ../content/person.py:36
 msgid "Firstname"
 msgstr "Ime"
 
-#: ../content/person.py:41
+#: ../content/person.py:40
 msgid "Gender"
 msgstr "Spol"
 
@@ -173,11 +173,11 @@ msgstr "Trenutna pozicija"
 msgid "IM handle"
 msgstr "IM krmilka"
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "Installs test data for the collective.contact.core package"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "Installs the collective.contact.core package"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgstr "Napačen email naslov"
 msgid "Invalid phone"
 msgstr "Napačna telefonska številka"
 
-#: ../content/person.py:33
+#: ../content/person.py:32
 msgid "Lastname"
 msgstr "Priimek"
 
@@ -201,7 +201,7 @@ msgstr "Priimek"
 msgid "Latitude"
 msgstr "Zemljepisna šririna"
 
-#: ../content/organization.py:38
+#: ../content/organization.py:39
 msgid "Logo"
 msgstr "Logotip"
 
@@ -233,11 +233,11 @@ msgstr ""
 msgid "Migration profile for collective.contact.core to 9"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:22
+#: ../browser/person_title_mapping.py:24
 msgid "Mr"
 msgstr ""
 
-#: ../browser/person_title_mapping.py:23
+#: ../browser/person_title_mapping.py:25
 msgid "Mrs"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgstr "Ni dodeljen"
 msgid "Number"
 msgstr "Številka"
 
-#: ../browser/addcontact.py:271
+#: ../browser/addcontact.py:274
 #: ../content/directory.py:37
 #: ../profiles/default/types/organization.xml
 msgid "Organization"
@@ -275,7 +275,7 @@ msgstr "Tip organizacije"
 msgid "Organization types"
 msgstr "Tipi organizacij"
 
-#: ../content/held_position.py:31
+#: ../interfaces.py:83
 msgid "Organization/Position"
 msgstr "Organizacija/pozicija"
 
@@ -297,13 +297,13 @@ msgstr "Drugi kontakti v tej organizaciji"
 msgid "Parent organizations"
 msgstr "Krovne organizacije"
 
-#: ../browser/addcontact.py:277
+#: ../browser/addcontact.py:280
 #: ../profiles/default/types/person.xml
 #: ../upgrades/profiles/v2/types/person.xml
 msgid "Person"
 msgstr "Oseba"
 
-#: ../content/person.py:47
+#: ../content/person.py:46
 msgid "Person title"
 msgstr "Naziv osebe"
 
@@ -319,12 +319,12 @@ msgstr "Telefon"
 msgid "Phone number"
 msgstr "Telefonske številke"
 
-#: ../content/held_position.py:49
-#: ../content/person.py:53
+#: ../content/person.py:52
+#: ../interfaces.py:101
 msgid "Photo"
 msgstr "Foto"
 
-#: ../browser/addcontact.py:283
+#: ../browser/addcontact.py:286
 #: ../browser/basefields/templates/held_position.pt:15
 #: ../content/directory.py:30
 msgid "Position"
@@ -359,21 +359,21 @@ msgstr "Sorodne organizacije"
 msgid "Search and attach organizations related to this one"
 msgstr "Poišči in pripni organizacijo, ki je sorodna tej"
 
-#: ../browser/addcontact.py:273
+#: ../browser/addcontact.py:276
 msgid "Select the organization where the person holds the position"
 msgstr "Izberi organizacijo"
 
-#: ../browser/addcontact.py:278
+#: ../browser/addcontact.py:281
 msgid "Select the person who holds the position"
 msgstr "Izberi osebo, ki zaseda pozicijo"
 
-#: ../browser/addcontact.py:285
+#: ../browser/addcontact.py:288
 msgid "Select the position held by this person in the selected organization"
 msgstr "Izberi pozicijo, ki jo zaseda ta oseba v izbrani organizaciji"
 
 #: ../browser/basefields/templates/held_position.pt:23
 #: ../browser/templates/heldpositions.pt:42
-#: ../content/held_position.py:41
+#: ../interfaces.py:93
 msgid "Start date"
 msgstr "Začetni datum"
 
@@ -385,6 +385,10 @@ msgstr ""
 msgid "Street"
 msgstr "Ulica"
 
+#: ../interfaces.py:39
+msgid "The person contact details are private and will not be used in other context, like held position."
+msgstr ""
+
 #: ../content/directory.py:22
 msgid "Token"
 msgstr "Žeton"
@@ -393,15 +397,15 @@ msgstr "Žeton"
 msgid "Type"
 msgstr "Tip"
 
-#: ../content/organization.py:33
+#: ../content/organization.py:34
 msgid "Type or level"
 msgstr "Tip ali nivo"
 
-#: ../interfaces.py:43
+#: ../interfaces.py:54
 msgid "Use description to search persons."
 msgstr "Uporabi opis za iskanje osebe"
 
-#: ../interfaces.py:38
+#: ../interfaces.py:49
 msgid "Use held positions to search persons."
 msgstr "Uporabi trenutne pozicije za iskanje osebe"
 
@@ -427,11 +431,11 @@ msgstr "Poštna številka"
 msgid "address_line"
 msgstr ""
 
-#: ../configure.zcml:49
+#: ../configure.zcml:50
 msgid "collective.contact.core"
 msgstr ""
 
-#: ../configure.zcml:57
+#: ../configure.zcml:58
 msgid "collective.contact.core test data"
 msgstr ""
 
@@ -450,21 +454,21 @@ msgid "from"
 msgstr "od"
 
 #. Default: "Please fill the organization first and then eventually select position"
-#: ../browser/addcontact.py:474
+#: ../browser/addcontact.py:469
 msgid "help_add_organization_or_position_organization"
 msgstr "Najprej vnesite organizacijo in nato po potrebi izberite pozicijo"
 
 #. Default: "Doctor, Mrs..."
-#: ../content/person.py:48
+#: ../content/person.py:47
 msgid "help_person_title"
 msgstr "dr., mag. ..."
 
 #. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../browser/addcontact.py:67
+#: ../browser/addcontact.py:69
 msgid "help_widget_add_new_elt"
 msgstr "Če predmet ne obstaja, ga lahko dodaš v podatkovno bazo"
 
-#: ../browser/addcontact.py:140
+#: ../browser/addcontact.py:142
 msgid "organization/position"
 msgstr "Organizacija/pozicija"
 

--- a/src/collective/contact/core/profiles/default/metadata.xml
+++ b/src/collective/contact/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>10</version>
+  <version>11</version>
   <dependencies>
     <dependency>profile-collective.contact.widget:default</dependency>
     <dependency>profile-plone.app.dexterity:default</dependency>

--- a/src/collective/contact/core/profiles/default/registry.xml
+++ b/src/collective/contact/core/profiles/default/registry.xml
@@ -1,32 +1,3 @@
 <registry>
-  <record name="collective.contact.core.interfaces.IContactCoreParameters.person_title_in_title"
-          interface="collective.contact.core.interfaces.IContactCoreParameters"
-          field="person_title_in_title">
-    <field type="plone.registry.field.Bool">
-      <default>True</default>
-      <required>False</required>
-      <title>Person title in title</title>
-    </field>
-    <value>True</value>
-  </record>
-  <record name="collective.contact.core.interfaces.IContactCoreParameters.use_held_positions_to_search_person"
-          interface="collective.contact.core.interfaces.IContactCoreParameters"
-          field="use_held_positions_to_search_person">
-    <field type="plone.registry.field.Bool">
-      <default>True</default>
-      <required>False</required>
-      <title>Use held positions to search persons</title>
-    </field>
-    <value>True</value>
-  </record>
-  <record name="collective.contact.core.interfaces.IContactCoreParameters.use_description_to_search_person"
-          interface="collective.contact.core.interfaces.IContactCoreParameters"
-          field="use_description_to_search_person">
-    <field type="plone.registry.field.Bool">
-      <default>True</default>
-      <required>False</required>
-      <title>Use description to search persons</title>
-    </field>
-    <value>True</value>
-  </record>
+  <records interface="collective.contact.core.interfaces.IContactCoreParameters" />
 </registry>

--- a/src/collective/contact/core/profiles/default/types/held_position.xml
+++ b/src/collective/contact/core/profiles/default/types/held_position.xml
@@ -21,6 +21,7 @@
  <property name="klass">collective.contact.core.content.held_position.HeldPosition</property>
  <property name="behaviors">
   <element value="plone.app.content.interfaces.INameFromTitle"/>
+  <element value="collective.contact.core.behaviors.IContactDetails" />
  </property>
  <property name="schema"/>
  <!-- DO NOT use a model_source or it removes manually added fields while reapplying the profile -->

--- a/src/collective/contact/core/setuphandlers.py
+++ b/src/collective/contact/core/setuphandlers.py
@@ -62,6 +62,31 @@ def create_test_contact_data(portal):
                            {'name': u'Regiment', 'token': u'regiment'},
                            {'name': u'Squad', 'token': u'squad'},
                            ]
+# Examples structure
+# ------------------
+# organizations (* = organization, £ = position)
+#     * Armée de terre
+#         * Corps A
+#             * Division Alpha
+#                 * Régiment H
+#                     * Brigade LH
+#                         £ Sergent
+#                 £ Capitaine
+#             * Division Beta
+#         * Corps B
+#         £ Général
+#
+# persons (> = person, @ = held_position)
+#     > De Gaulle
+#         @ Armée de terre
+#         @ Général
+#     > Pepper
+#         @ Sergent
+#     > Rambo
+#         @ Brigade LH
+#     > Draper
+#         @ Capitaine
+#         @ Division Beta
 
     params = {'title': u"Military directory",
               'position_types': position_types,
@@ -76,7 +101,7 @@ def create_test_contact_data(portal):
               'gender': u'M',
               'person_title': u'Général',
               'birthday': datetime.date(1901, 11, 22),
-              'email': u'charles.de.gaulle@armees.fr',
+              'email': u'charles.de.gaulle@private.com',
               'country': u'France',
               'city': u"Colombey les deux églises",
               'number': u'6bis',
@@ -91,14 +116,14 @@ def create_test_contact_data(portal):
 
     params = {'lastname': u'Pepper',
               'gender': u'M',
-              'person_title': u'Sergent',
+              'person_title': u'Mister',
               'birthday': datetime.date(1967, 6, 1),
-              'email': u'sgt.pepper@armees.fr',
-              'phone': u'0288552211',
+              'email': u'stephen.pepper@private.com',
+              'phone': u'0288443344',
               'city': u'Liverpool',
               'country': u'England',
               'use_parent_address': False,
-              'website': 'http://www.sergent-pepper.org'
+              'website': 'http://www.stephen-pepper.org'
               }
     mydirectory.invokeFactory('person', 'pepper', **params)
     pepper = mydirectory['pepper']
@@ -109,18 +134,27 @@ def create_test_contact_data(portal):
               'use_parent_address': True,
               }
     mydirectory.invokeFactory('person', 'rambo', **params)
+    rambo = mydirectory['rambo']
 
     params = {'lastname': u'Draper',
               'firstname': u'John',
               'person_title': u'Mister',
-              'use_parent_address': True,
+              'use_parent_address': False,
               }
+
     mydirectory.invokeFactory('person', 'draper', **params)
     draper = mydirectory['draper']
 
     params = {'title': u"Armée de terre",
               'organization_type': u'army',
-              'use_parent_address': True,
+              'phone': u'01000000001',
+              'email': u'contact@armees.fr',
+              'use_parent_address': False,
+              'city': u'Paris',
+              'street': u'Avenue des Champs-Élysées',
+              'number': u'1',
+              'zip_code': u'75008',
+              'country': u'France',
               }
     mydirectory.invokeFactory('organization', 'armeedeterre', **params)
     armeedeterre = mydirectory['armeedeterre']
@@ -154,6 +188,7 @@ def create_test_contact_data(portal):
     corpsa.invokeFactory('organization', 'divisionbeta', **params)
 
     divisionalpha = corpsa['divisionalpha']
+    divisionbeta = corpsa['divisionbeta']
 
     params = {'title': u"Régiment H",
               'organization_type': u'regiment',
@@ -176,7 +211,13 @@ def create_test_contact_data(portal):
 
     params = {'title': u"Général de l'armée de terre",
               'position_type': u'general',
-              'use_parent_address': True,
+              'email': u'general@armees.fr',
+              'use_parent_address': False,
+              'city': u'Lille',
+              'street': u"Rue de la Porte d'Ypres",
+              'number': u'1',
+              'zip_code': u'59800',
+              'country': u'France',
               }
     armeedeterre.invokeFactory('position', 'general_adt', **params)
 
@@ -209,18 +250,41 @@ def create_test_contact_data(portal):
     params = {'start_date': datetime.date(1940, 5, 25),
               'end_date': datetime.date(1970, 11, 9),
               'position': RelationValue(intids.getId(general_adt)),
-              'label': u"Émissaire OTAN"
+              'label': u"Émissaire OTAN",
+              'phone': u'0987654321',
+              'country': u'France',
+              'use_parent_address': True,
               }
     degaulle.invokeFactory('held_position', 'gadt', **params)
 
     params = {'start_date': datetime.date(1980, 6, 5),
               'position': RelationValue(intids.getId(sergent_lh)),
+              'email': u'sgt.pepper@armees.fr',
+              'phone': u'0288552211',
+              'city': u'Liverpool',
+              'street': u'Water Street',
+              'number': u'1',
+              'zip_code': u'L3 4FP',
+              'country': u'England',
+              'use_parent_address': False,
+              'website': 'http://www.sergent-pepper.org'
               }
     pepper.invokeFactory('held_position', 'sergent_pepper', **params)
 
     params = {'position': RelationValue(intids.getId(capitaine_alpha)),
+              'use_parent_address': True,
               }
     draper.invokeFactory('held_position', 'captain_crunch', **params)
+
+    params = {'position': RelationValue(intids.getId(divisionbeta)),
+              'use_parent_address': True,
+              }
+    draper.invokeFactory('held_position', 'divisionbeta', **params)
+
+    params = {'position': RelationValue(intids.getId(brigadelh)),
+              'use_parent_address': True,
+              }
+    rambo.invokeFactory('held_position', 'brigadelh', **params)
 
 
 def createTestData(context):

--- a/src/collective/contact/core/setuphandlers.py
+++ b/src/collective/contact/core/setuphandlers.py
@@ -15,8 +15,13 @@ from zope.intid.interfaces import IIntIds
 
 from z3c.relationfield.relation import RelationValue
 
+from plone import api
+#from plone.registry.interfaces import IRegistry
+
 import logging
 logger = logging.getLogger('collective.contact.core: setuphandlers')
+
+from collective.contact.core.interfaces import IContactCoreParameters
 
 
 def isNotCollectiveContactContentProfile(context):
@@ -38,6 +43,14 @@ def postInstall(context):
     for line in traceback.format_stack():
         if 'QuickInstallerTool.py' in line and 'reinstallProducts' in line:
             raise Exception('You can not reinstall this product, use portal_setup to re-apply the relevant profile !')
+    # Set default values in registry
+    for name in ('person_contact_details_private', 'person_title_in_title', 'use_held_positions_to_search_person',
+                 'use_description_to_search_person'):
+        val = api.portal.get_registry_record(name=name, interface=IContactCoreParameters)
+        if val is None:
+            api.portal.set_registry_record(name=name, value=True, interface=IContactCoreParameters)
+    api.portal.set_registry_record(name='person_contact_details_private', value=False,
+                                   interface=IContactCoreParameters)
     # we need to remove the default model_source added to our portal_types
     # XXX to be done
 

--- a/src/collective/contact/core/subscribers.py
+++ b/src/collective/contact/core/subscribers.py
@@ -22,10 +22,10 @@ except ImportError:
 
 from collective.contact.widget.interfaces import IContactContent
 from collective.contact.core.behaviors import IContactDetails
-from collective.contact.core.content.held_position import IHeldPosition
 from collective.contact.core.content.position import IPosition
 from collective.contact.core.content.person import IPerson
 from collective.contact.core.content.organization import IOrganization
+from collective.contact.core.interfaces import IHeldPosition
 
 # update indexes of related content when a content is modified
 # you can monkey patch this value if you have an index that needs this

--- a/src/collective/contact/core/tests/robot/test_contacts.robot
+++ b/src/collective/contact/core/tests/robot/test_contacts.robot
@@ -10,7 +10,7 @@ Directory is available
     [Tags]    Go
     Log in as site owner and wait
     Click link    css=#portaltab-mydirectory a
-    Element should contain    css=#content h1    Military directory
+    Wait until element is visible  xpath=//h1[.='Military directory']  5
 
 Create a new organization
     [Tags]    Go

--- a/src/collective/contact/core/tests/test_adapters.py
+++ b/src/collective/contact/core/tests/test_adapters.py
@@ -12,7 +12,7 @@ from ecreall.helpers.testing.base import BaseTest
 
 from collective.contact.core.testing import INTEGRATION
 from collective.contact.core.interfaces import IVCard, IPersonHeldPositions,\
-    IContactable
+    IContactable, IContactCoreParameters
 
 
 class TestAdapters(unittest.TestCase, BaseTest):
@@ -30,12 +30,22 @@ class TestAdapters(unittest.TestCase, BaseTest):
     def test_gadt_vcard(self):
         gadt = self.degaulle['gadt']
         vcard_provider = IVCard(gadt)
+        api.portal.set_registry_record(name='person_contact_details_private', value=True,
+                                       interface=IContactCoreParameters)
         vcard = vcard_provider.get_vcard()
         self.assertEqual(vcard.fn.value, u'Charles De Gaulle')
         self.assertEqual(vcard.org.value, [u'Armée de terre'])
         self.assertEqual(vcard.role.value, u"Général de l'armée de terre")
         self.assertEqual(vcard.title.value, u"Général de l'armée de terre")
         self.assertEqual(vcard.email.value, 'general@armees.fr')
+        self.assertEqual(vcard.email.type_param, 'INTERNET')
+        self.assertTrue(hasattr(vcard, 'adr'))
+        self.assertTrue(hasattr(vcard, 'tel_list'))
+        self.assertEqual(vcard.bday.value, '1901-11-22')
+        api.portal.set_registry_record(name='person_contact_details_private', value=False,
+                                       interface=IContactCoreParameters)
+        vcard = vcard_provider.get_vcard()
+        self.assertEqual(vcard.email.value, 'charles.de.gaulle@private.com')
         self.assertEqual(vcard.email.type_param, 'INTERNET')
         self.assertTrue(hasattr(vcard, 'adr'))
         self.assertTrue(hasattr(vcard, 'tel_list'))
@@ -103,6 +113,9 @@ class TestAdapters(unittest.TestCase, BaseTest):
         self.assertEqual(adapter.get_main_position(), degaulle.gadt)
 
     def test_contact_details(self):
+        ## person contact details are private
+        api.portal.set_registry_record(name='person_contact_details_private', value=True,
+                                       interface=IContactCoreParameters)
         # test a person
         details = IContactable(self.degaulle).get_contact_details()
         self.assertEqual(details['website'], 'http://www.charles-de-gaulle.org')
@@ -155,6 +168,60 @@ class TestAdapters(unittest.TestCase, BaseTest):
                                                   'region': '',
                                                   'street': u'Avenue des Champs-\xc9lys\xe9es',
                                                   'zip_code': u'75008'})
+
+        # test an held position not using parent address
+        details = IContactable(self.pepper['sergent_pepper']).get_contact_details()
+        self.assertEqual(details['email'], u'sgt.pepper@armees.fr')
+        self.assertEqual(details['phone'], u'0288552211')
+        self.assertDictEqual(details['address'], {'additional_address_details': '',
+                                                  'city': u'Liverpool',
+                                                  'country': u'England',
+                                                  'number': u'1',
+                                                  'region': '',
+                                                  'street': u'Water Street',
+                                                  'zip_code': u'L3 4FP'})
+
+        ## person contact details are not private
+        api.portal.set_registry_record(name='person_contact_details_private', value=False,
+                                       interface=IContactCoreParameters)
+        # test an held position using parent address and related to an organization
+        details = IContactable(self.degaulle['adt']).get_contact_details()
+        self.assertEqual(details['email'], u'charles.de.gaulle@private.com')  # phone from person
+        self.assertEqual(details['phone'], u'01000000001')  # phone from org
+        self.assertDictEqual(details['address'], {'additional_address_details': u'b\xe2timent D',
+                                                  'city': u'Colombey les deux \xe9glises',
+                                                  'country': u'France',
+                                                  'number': u'6bis',
+                                                  'region': '',
+                                                  'street': u'rue Jean Moulin',
+                                                  'zip_code': u'52330'})
+
+        # test an held position using parent address and related to a position
+        self.assertFalse(self.directory['armeedeterre']['general_adt'].use_parent_address)
+        details = IContactable(self.degaulle['gadt']).get_contact_details()
+        self.assertEqual(details['email'], u'charles.de.gaulle@private.com')
+        self.assertEqual(details['phone'], u'0987654321')
+        self.assertDictEqual(details['address'], {'additional_address_details': u'b\xe2timent D',
+                                                  'city': u'Colombey les deux \xe9glises',
+                                                  'country': u'France',
+                                                  'number': u'6bis',
+                                                  'region': '',
+                                                  'street': u'rue Jean Moulin',
+                                                  'zip_code': u'52330'})
+
+        # test an held position using parent address and related to a position using parent address
+        self.directory['armeedeterre']['general_adt'].use_parent_address = True
+        details = IContactable(self.degaulle['gadt']).get_contact_details()
+        self.directory['armeedeterre']['general_adt'].use_parent_address = False
+        self.assertEqual(details['email'], u'charles.de.gaulle@private.com')
+        self.assertEqual(details['phone'], u'0987654321')
+        self.assertDictEqual(details['address'], {'additional_address_details': u'b\xe2timent D',
+                                                  'city': u'Colombey les deux \xe9glises',
+                                                  'country': u'France',
+                                                  'number': u'6bis',
+                                                  'region': '',
+                                                  'street': u'rue Jean Moulin',
+                                                  'zip_code': u'52330'})
 
         # test an held position not using parent address
         details = IContactable(self.pepper['sergent_pepper']).get_contact_details()

--- a/src/collective/contact/core/tests/test_adapters.py
+++ b/src/collective/contact/core/tests/test_adapters.py
@@ -35,10 +35,10 @@ class TestAdapters(unittest.TestCase, BaseTest):
         self.assertEqual(vcard.org.value, [u'Armée de terre'])
         self.assertEqual(vcard.role.value, u"Général de l'armée de terre")
         self.assertEqual(vcard.title.value, u"Général de l'armée de terre")
-        self.assertEqual(vcard.email.value, 'charles.de.gaulle@armees.fr')
+        self.assertEqual(vcard.email.value, 'general@armees.fr')
         self.assertEqual(vcard.email.type_param, 'INTERNET')
         self.assertTrue(hasattr(vcard, 'adr'))
-        self.assertFalse(hasattr(vcard, 'tel_list'))
+        self.assertTrue(hasattr(vcard, 'tel_list'))
         self.assertEqual(vcard.bday.value, '1901-11-22')
 
     def test_sgt_pepper_vcard(self):
@@ -103,9 +103,10 @@ class TestAdapters(unittest.TestCase, BaseTest):
         self.assertEqual(adapter.get_main_position(), degaulle.gadt)
 
     def test_contact_details(self):
+        # test a person
         details = IContactable(self.degaulle).get_contact_details()
         self.assertEqual(details['website'], 'http://www.charles-de-gaulle.org')
-        self.assertEqual(details['email'], 'charles.de.gaulle@armees.fr')
+        self.assertEqual(details['email'], 'charles.de.gaulle@private.com')
         self.assertEqual(details['address'], {'city': u'Colombey les deux \xe9glises',
                                               'country': u'France', 'region': '',
                                               'additional_address_details': u'b\xe2timent D',
@@ -114,7 +115,55 @@ class TestAdapters(unittest.TestCase, BaseTest):
                                               'zip_code': u'52330'})
 
         details = IContactable(self.degaulle).get_contact_details(keys=('email',))
-        self.assertEqual(details, {'email': 'charles.de.gaulle@armees.fr'})
+        self.assertEqual(details, {'email': 'charles.de.gaulle@private.com'})
 
-        details = IContactable(self.pepper).get_contact_details()
-        self.assertEqual(details['website'], 'http://www.sergent-pepper.org')
+        # test an held position using parent address and related to an organization
+        details = IContactable(self.degaulle['adt']).get_contact_details()
+        self.assertEqual(details['email'], u'contact@armees.fr')  # phone from org
+        self.assertEqual(details['phone'], u'01000000001')  # phone from org
+        self.assertDictEqual(details['address'], {'additional_address_details': '',
+                                                  'city': u'Paris',
+                                                  'country': u'France',
+                                                  'number': u'1',
+                                                  'region': '',
+                                                  'street': u'Avenue des Champs-\xc9lys\xe9es',
+                                                  'zip_code': u'75008'})
+
+        # test an held position using parent address and related to a position
+        self.assertFalse(self.directory['armeedeterre']['general_adt'].use_parent_address)
+        details = IContactable(self.degaulle['gadt']).get_contact_details()
+        self.assertEqual(details['email'], u'general@armees.fr')
+        self.assertEqual(details['phone'], u'0987654321')
+        self.assertDictEqual(details['address'], {'additional_address_details': '',
+                                                  'city': u'Lille',
+                                                  'country': u'France',
+                                                  'number': u'1',
+                                                  'region': '',
+                                                  'street': u"Rue de la Porte d'Ypres",
+                                                  'zip_code': u'59800'})
+
+        # test an held position using parent address and related to a position using parent address
+        self.directory['armeedeterre']['general_adt'].use_parent_address = True
+        details = IContactable(self.degaulle['gadt']).get_contact_details()
+        self.directory['armeedeterre']['general_adt'].use_parent_address = False
+        self.assertEqual(details['email'], u'general@armees.fr')
+        self.assertEqual(details['phone'], u'0987654321')
+        self.assertDictEqual(details['address'], {'additional_address_details': '',
+                                                  'city': u'Paris',
+                                                  'country': u'France',
+                                                  'number': u'1',
+                                                  'region': '',
+                                                  'street': u'Avenue des Champs-\xc9lys\xe9es',
+                                                  'zip_code': u'75008'})
+
+        # test an held position not using parent address
+        details = IContactable(self.pepper['sergent_pepper']).get_contact_details()
+        self.assertEqual(details['email'], u'sgt.pepper@armees.fr')
+        self.assertEqual(details['phone'], u'0288552211')
+        self.assertDictEqual(details['address'], {'additional_address_details': '',
+                                                  'city': u'Liverpool',
+                                                  'country': u'England',
+                                                  'number': u'1',
+                                                  'region': '',
+                                                  'street': u'Water Street',
+                                                  'zip_code': u'L3 4FP'})

--- a/src/collective/contact/core/tests/test_content_types.py
+++ b/src/collective/contact/core/tests/test_content_types.py
@@ -64,7 +64,7 @@ class TestPerson(TestContentTypes):
 
     def test_no_firstname(self):
         pepper = self.mydirectory['pepper']
-        self.assertEqual('Sergent Pepper', pepper.Title())
+        self.assertEqual('Mister Pepper', pepper.Title())
 
     def test_no_person_title(self):
         rambo = self.mydirectory['rambo']
@@ -217,7 +217,7 @@ class TestHeldPosition(TestContentTypes):
         self.assertEqual(self.gadt.get_full_title(),
                          u"Général Charles De Gaulle (Armée de terre - Général de l'armée de terre)")
         self.assertEqual(self.sergent_pepper.get_full_title(),
-                         u"Sergent Pepper (Armée de terre - Sergent de la brigade LH)")
+                         u"Mister Pepper (Armée de terre - Sergent de la brigade LH)")
         self.assertEqual(self.gadt.get_person_title(),
                          u"Général Charles De Gaulle")
 

--- a/src/collective/contact/core/tests/test_search.py
+++ b/src/collective/contact/core/tests/test_search.py
@@ -44,7 +44,7 @@ class TestSearch(unittest.TestCase, BaseTest):
                          u"Général Charles De Gaulle Général de l'armée de terre Armée de terre Émissaire OTAN")
         sergent_pepper = self.sergent_pepper
         self.assertEqual(held_position_searchable_text(sergent_pepper)(),
-                         u"Sergent Pepper Sergent de la brigade LH Armée de terre Corps A Division Alpha Régiment H Brigade LH")
+                         u"Mister Pepper Sergent de la brigade LH Armée de terre Corps A Division Alpha Régiment H Brigade LH")
         pepper = self.pepper
         self.assertEqual(person_sortable_title(pepper)(),
                          "pepper")
@@ -67,7 +67,7 @@ class TestSearch(unittest.TestCase, BaseTest):
         results = catalog.searchResults(SearchableText='Général')
         self.assertEqual(len(results), 4)
         results = catalog.searchResults(SearchableText='Corps')
-        self.assertEqual(len(results), 10)
+        self.assertEqual(len(results), 13)
         results_objects = [res.getObject() for res in results]
         self.assertIn(self.corpsa, results_objects)
         self.assertIn(self.corpsb, results_objects)
@@ -77,20 +77,20 @@ class TestSearch(unittest.TestCase, BaseTest):
         self.assertIn(self.brigadelh, results_objects)
         self.assertIn(self.sergent_pepper, results_objects)
         results = catalog.searchResults(SearchableText='armée')
-        self.assertEqual(len(results), 15)
+        self.assertEqual(len(results), 18)
         results = catalog.searchResults(SearchableText='beta')
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 3)
         results = catalog.searchResults(SearchableText='régiment')
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 6)
         results = catalog.searchResults(SearchableText='brigade')
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 6)
         results = catalog.searchResults(SearchableText='Émissaire')
         self.assertEqual(len(results), 2)
         results = catalog.searchResults(portal_type='held_position')
-        self.assertEqual(len(results), 4)
+        self.assertEqual(len(results), 6)
         results = catalog.searchResults(portal_type='held_position',
                                         start={'query': datetime.date(1981, 1, 1), 'range': 'min'})
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 3)
         results = catalog.searchResults(portal_type='held_position',
                                         end={'query': datetime.date(1971, 1, 1), 'range': 'max'})
         self.assertEqual(len(results), 2)

--- a/src/collective/contact/core/tests/test_views.py
+++ b/src/collective/contact/core/tests/test_views.py
@@ -192,7 +192,7 @@ class TestOrganizationView(TestView):
     def test_organization_contact_details_view(self):
         view = self.corpsa.restrictedTraverse("@@contactdetails")
         view.update()
-        self.assertEqual(view.contact_details['email'], '')
+        self.assertEqual(view.contact_details['email'], 'contact@armees.fr')
 
         address = view.contact_details['address']
         self.assertEqual(address['number'], u'')
@@ -233,12 +233,12 @@ class TestOrganizationView(TestView):
         self.assertEqual(contact['held_position'], 'Armée de terre')
         self.assertIsNone(contact['label'])
         self.assertEqual(contact['obj'], self.adt)
-        self.assertEqual(contact['email'], u'charles.de.gaulle@armees.fr')
+        self.assertEqual(contact['email'], None)
         self.assertIsNone(contact['phone'])
         self.assertIsNone(contact['cell_phone'])
         self.assertIsNone(contact['fax'])
         self.assertIsNone(contact['im_handle'])
-        self.assertEqual(contact['website'], 'http://www.charles-de-gaulle.org')
+        self.assertEqual(contact['website'], None)
 
 
 class TestPersonView(TestView):
@@ -253,7 +253,7 @@ class TestPersonView(TestView):
     def test_person_contact_details_view(self):
         view = self.degaulle.restrictedTraverse("@@contactdetails")
         view.update()
-        self.assertEqual(view.contact_details['email'], 'charles.de.gaulle@armees.fr')
+        self.assertEqual(view.contact_details['email'], 'charles.de.gaulle@private.com')
         self.assertEqual(view.contact_details['phone'], '')
         self.assertEqual(view.contact_details['cell_phone'], '')
         self.assertEqual(view.contact_details['im_handle'], '')

--- a/src/collective/contact/core/upgrades/upgrades.py
+++ b/src/collective/contact/core/upgrades/upgrades.py
@@ -7,6 +7,7 @@ from zope.component import getUtility
 
 from plone import api
 
+from collective.contact.core.interfaces import IContactCoreParameters
 from collective.contact.widget.interfaces import IContactContent
 from ecreall.helpers.upgrade.interfaces import IUpgradeTool
 
@@ -80,3 +81,12 @@ def v10(context):
     brains = catalog.searchResults(object_provides=IHeldPosition.__identifier__)
     for brain in brains:
         brain.getObject().reindexObject(['start', 'end'])
+
+
+def v11(context):
+    IUpgradeTool(context).runImportStep('collective.contact.core', 'typeinfo')
+    IUpgradeTool(context).runImportStep('collective.contact.core', 'plone.app.registry')
+    val = api.portal.get_registry_record(name='person_contact_details_private', interface=IContactCoreParameters)
+    if val is None:
+        api.portal.set_registry_record(name='person_contact_details_private', value=True,
+                                       interface=IContactCoreParameters)

--- a/src/collective/contact/core/upgrades/upgrades.py
+++ b/src/collective/contact/core/upgrades/upgrades.py
@@ -10,7 +10,7 @@ from plone import api
 from collective.contact.widget.interfaces import IContactContent
 from ecreall.helpers.upgrade.interfaces import IUpgradeTool
 
-from ..content.held_position import IHeldPosition
+from ..interfaces import IHeldPosition
 
 
 def reindex_relations(context):


### PR DESCRIPTION
When adding contact details behavior on held position, it's now possible to define specific contact information linked to an held position (personal email in the organization, etc.). 

By default, person contact details are considered as personal data (the personal person address, the personal phone, etc.). Held position details can contains professional information. Now possible to have both personal and work details. 
If held position details are missing, the person details are no more used but only linked position or organization.

New option added in the registry for this privacy behavior. When setting to false, old behavior is considered. Person details can be used in professional context.