### PR TITLE
Use organization full title in held_position and position get_full_title methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.18 (unreleased)
 -----------------
 
+- Use real full title in held_position and position get_full_title methods.
+  Necessary to display to the end user the right organization, without ambiguity.
+  [sgeulette]
 
 - Prevent address fields from being erased if they are changed programmaticaly before any manual edition.
   [thomasdesvenain]

--- a/src/collective/contact/core/browser/person.py
+++ b/src/collective/contact/core/browser/person.py
@@ -58,7 +58,7 @@ class HeldPositions(grok.View):
             # held_position['email'] = obj.email
             held_position['object'] = obj
             organization = obj.get_organization()
-            held_position['organization'] = organization.get_root_organization() if organization else None
+            held_position['organization'] = organization if organization else None
             held_position['can_edit'] = sm.checkPermission('Modify portal content', obj)
             held_position['can_delete'] = sm.checkPermission('Delete objects', obj)
             held_positions.append(held_position)

--- a/src/collective/contact/core/browser/templates/heldpositions.pt
+++ b/src/collective/contact/core/browser/templates/heldpositions.pt
@@ -58,7 +58,7 @@
                            tal:replace="structure python:scales.tag('logo', 'tile', css_class='photo')"
                            tal:on-error="string:Bad logo format" />
                   </div>
-                  <h4><a tal:attributes="href organization/absolute_url" tal:content="organization/Title"></a></h4>
+                  <h4><a tal:attributes="href organization/absolute_url" tal:content="organization/get_full_title"></a></h4>
 
                   <div tal:replace="structure held_position/organization/@@contactdetails"></div>
               </div>

--- a/src/collective/contact/core/content/held_position.py
+++ b/src/collective/contact/core/content/held_position.py
@@ -107,10 +107,10 @@ class HeldPosition(Container):
                                         organization.Title(),
                                         root_organization.Title())
 
-    def get_full_title(self):
+    def get_full_title(self, separator=u' / ', first_index=0):
         """Returns the 'full title' of the held position.
         It is constituted by the person's who held the position name,
-        the root organization and the position name (if any)
+        the full root organization and the position name (if any)
         """
         person_name = self.get_person_title()
         if self.position.to_object is None:  # the reference was removed
@@ -118,20 +118,17 @@ class HeldPosition(Container):
 
         position = self.get_position()
         organization = self.get_organization()
-        root_organization = organization.get_root_organization().title
         if position is None and not self.label:
             return u"%s (%s)" % (person_name,
-                                 root_organization)
+                                 organization.get_full_title(separator=separator, first_index=first_index))
         elif position is None and self.label:
-            position_name = self.label
-            return u"%s (%s - %s)" % (person_name,
-                                      root_organization,
-                                      position_name)
+            return u"%s (%s, %s)" % (person_name,
+                                      organization.get_full_title(separator=separator, first_index=first_index),
+                                      self.label)
         else:
-            position_name = position.title
-            return u"%s (%s - %s)" % (person_name,
-                                      root_organization,
-                                      position_name)
+            return u"%s (%s, %s)" % (person_name,
+                                      organization.get_full_title(separator=separator, first_index=first_index),
+                                      position.title)
 
     def get_person_title(self):
         person = self.get_person()

--- a/src/collective/contact/core/content/position.py
+++ b/src/collective/contact/core/content/position.py
@@ -71,19 +71,13 @@ class Position(Container):
         chain.append(self)
         return chain
 
-    def get_full_title(self):
+    def get_full_title(self, separator=u' / ', first_index=0):
         """Returns the full title of the position
         It is constituted by the name of the position,
-        the name of its organization and the name of the
-        root organization in brackets.
+        the full name of its organization.
         """
         organization = self.get_organization()
-        root_organization = organization.get_root_organization()
-        if organization == root_organization:
-            return u"%s (%s)" % (self.title, organization.title)
-        else:
-            return u"%s, %s (%s)" % (self.title, organization.title,
-                                     root_organization.title)
+        return u"%s (%s)" % (self.title, organization.get_full_title(separator=separator, first_index=first_index))
 
     def get_held_positions(self):
         """Returns the held position

--- a/src/collective/contact/core/tests/robot/test_contacts.robot
+++ b/src/collective/contact/core/tests/robot/test_contacts.robot
@@ -71,13 +71,14 @@ Can create new contact from position
     Wait For Condition    return $('.overlay h1').text() === "Create Contact"
     Element should not be visible    css=#oform-widgets-position-input-fields
     Element should contain    oform-widgets-organization-input-fields    Armée de terre / Corps A / Division Alpha / Régiment H / Brigade LH
+    Sleep  1
     Input text    oform-widgets-person-widgets-query    Ramb
     Click element    oform-widgets-person-widgets-query
     Wait Until Page Contains Element    css=.ac_results
     Click element    css=.ac_results li:nth-child(1)
     Sleep  1
     Element should become visible    css=#oform-widgets-position-input-fields
-    Element should contain    oform-widgets-position-input-fields    Sergent de la brigade LH, Brigade LH (Armée de terre)
+    Element should contain    oform-widgets-position-input-fields    Sergent de la brigade LH (Armée de terre / Corps A / Division Alpha / Régiment H / Brigade LH)
     Click button    Add
 
 Show parent address if it exists in creation

--- a/src/collective/contact/core/tests/test_content_types.py
+++ b/src/collective/contact/core/tests/test_content_types.py
@@ -182,7 +182,8 @@ class TestPosition(TestContentTypes):
         self.assertEqual(self.general_adt.get_full_title(),
                          u"Général de l'armée de terre (Armée de terre)")
         self.assertEqual(self.sergent_lh.get_full_title(),
-                         u"Sergent de la brigade LH, Brigade LH (Armée de terre)")
+                         u"Sergent de la brigade LH (Armée de terre / Corps A / Division Alpha / Régiment H / "
+                         u"Brigade LH)")
 
     def test_copy_paste(self):
         cb = self.armeedeterre.manage_copyObjects(['general_adt'])
@@ -215,9 +216,10 @@ class TestHeldPosition(TestContentTypes):
         self.assertEqual(self.adt.get_full_title(),
                          u"Général Charles De Gaulle (Armée de terre)")
         self.assertEqual(self.gadt.get_full_title(),
-                         u"Général Charles De Gaulle (Armée de terre - Général de l'armée de terre)")
+                         u"Général Charles De Gaulle (Armée de terre, Général de l'armée de terre)")
         self.assertEqual(self.sergent_pepper.get_full_title(),
-                         u"Mister Pepper (Armée de terre - Sergent de la brigade LH)")
+                         u"Mister Pepper (Armée de terre / Corps A / Division Alpha / Régiment H / Brigade LH, "
+                         u"Sergent de la brigade LH)")
         self.assertEqual(self.gadt.get_person_title(),
                          u"Général Charles De Gaulle")
 

--- a/src/collective/contact/core/tests/test_views.py
+++ b/src/collective/contact/core/tests/test_views.py
@@ -147,7 +147,8 @@ class TestPositionView(TestView):
     def test_position_basefields_view(self):
         view = self.sergent_lh.restrictedTraverse("@@basefields")
         view.update()
-        self.assertEqual(view.name, u"Sergent de la brigade LH, Brigade LH (Armée de terre)")
+        self.assertEqual(view.name, u"Sergent de la brigade LH (Armée de terre / Corps A / Division Alpha / "
+                         u"Régiment H / Brigade LH)")
         self.assertEqual(view.type, "Sergeant")
 
     def test_position_view(self):


### PR DESCRIPTION
Actually get_full_tile on held positions display root organization.
There is an ambiguity for the end users when he has to choose a contact in contact fields. 
By example.
If John Rambo has a held position linked to "Army / Squadron G / Office" and another to "Army / Squadron H / Office", twice held positions were displayed in a contact field has "John Rambo (Army)".
End user could not see enough information to choose the right one.
Now an held position is displayed like "John Rambo (Army / Squadron G / Office)" or "John Rambo (Army / Squadron G / Office, Sergeant)"