### PR TITLE
Display positions on the organization view respecting order (getObjPositionInParent).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Changelog
   (See https://github.com/plone/plone.app.textfield/issues/22).
   [gbastien]
 
+- Display positions on the organization view respecting order (getObjPositionInParent).
+  [gbastien]
+
+
 1.17 (2017-10-02)
 -----------------
 

--- a/src/collective/contact/core/content/organization.py
+++ b/src/collective/contact/core/content/organization.py
@@ -133,7 +133,8 @@ class Organization(Container):
         catalog = api.portal.get_tool('portal_catalog')
         positions = catalog.searchResults(portal_type="position",
                                           path={'query': '/'.join(self.getPhysicalPath()),
-                                                'depth': 1})
+                                                'depth': 1},
+                                          sort_on='getObjPositionInParent')
         return [c.getObject() for c in positions]
 
     def get_held_positions(self):

--- a/src/collective/contact/core/tests/test_content_types.py
+++ b/src/collective/contact/core/tests/test_content_types.py
@@ -167,6 +167,22 @@ class TestOrganization(TestContentTypes):
         self.mydirectory.manage_pasteObjects(cb)
         self.assertIn('copy_of_armeedeterre', self.mydirectory.keys())
 
+    def test_get_positions(self):
+        # add some positions to self.armeedeterre
+        self.armeedeterre.invokeFactory('position', 'colonel_adt', title="Colonel de l'armée de terre")
+        self.armeedeterre.invokeFactory('position', 'lieutenant_adt', title="Lieutenant de l'armée de terre")
+        self.armeedeterre.invokeFactory('position', 'sergent_adt', title="Sergent de l'armée de terre")
+        self.assertEquals(
+            [pos.id for pos in self.armeedeterre.get_positions()],
+            ['general_adt', 'colonel_adt', 'lieutenant_adt', 'sergent_adt'])
+        # get_positions sorts positions using getObjPositionInParent
+        # move 'general_adt' to last position
+        self.armeedeterre.moveObjectToPosition(
+            'general_adt', len(self.armeedeterre.objectIds()))
+        self.assertEquals(
+            [pos.id for pos in self.armeedeterre.get_positions()],
+            ['colonel_adt', 'lieutenant_adt', 'sergent_adt', 'general_adt'])
+
 
 class TestPosition(TestContentTypes):
 


### PR DESCRIPTION
Hi @vincentfretin 

in our case, position order is important, we need to display contacts respecting a hierarchic order, so we make sure organization.get_positions respect the order of position objects stored in the organization container.

Please review and merge, and thank you for previous work!

Gauthier