### PR TITLE
add person email to searchabletext

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.19 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add email to SearchableText of a person. Useful when fixing contact data for
+  smtp error reports after sending a newsletter with collectice.contact.mailaction
 
 
 1.18 (2018-06-07)

--- a/src/collective/contact/core/indexers.py
+++ b/src/collective/contact/core/indexers.py
@@ -6,6 +6,7 @@ from Products.CMFPlone.utils import safe_unicode
 from collective.contact.core.content.organization import IOrganization
 from collective.contact.core.content.position import IPosition
 from collective.contact.core.content.person import IPerson
+from collective.contact.core.behaviors import IContactDetails
 from collective.contact.core.behaviors import IRelatedOrganizations
 from collective.contact.core.interfaces import IHeldPosition
 
@@ -58,6 +59,9 @@ def person_searchable_text(obj):
         text = obj.Title()
 
     results.append(safe_unicode(text))
+
+    results.append(IContactDetails(obj).email)
+
     use_held_positions = api.portal.get_registry_record(
         "collective.contact.core.interfaces.IContactCoreParameters."
         "use_held_positions_to_search_person")

--- a/src/collective/contact/core/indexers.py
+++ b/src/collective/contact/core/indexers.py
@@ -20,6 +20,11 @@ def organization_searchable_text(organization):
             words += related.to_object.get_organizations_titles()
 
     words += organization.get_organizations_titles()
+
+    email = IContactDetails(organization).email
+    if email:
+        words.append(email)
+
     return u' '.join(words)
 
 
@@ -38,13 +43,21 @@ def held_position_searchable_text(obj):
     if obj.label:
         indexed_fields.append(obj.label)
 
+    email = IContactDetails(obj).email
+    if email:
+        indexed_fields.append(email)
+
     return u' '.join(indexed_fields)
 
 
 @indexer(IPosition)
 def position_searchable_text(obj):
-    return u"%s %s" % (safe_unicode(obj.SearchableText()),
-                       safe_unicode(obj.get_organization().Title()))
+    result = [safe_unicode(obj.SearchableText())]
+    result.append(safe_unicode(obj.get_organization().Title()))
+    email = IContactDetails(obj).email
+    if email:
+        result.append(email)
+    return u' '.join(result)
 
 
 @indexer(IPerson)
@@ -60,7 +73,9 @@ def person_searchable_text(obj):
 
     results.append(safe_unicode(text))
 
-    results.append(IContactDetails(obj).email)
+    email = IContactDetails(obj).email
+    if email:
+        results.append(email)
 
     use_held_positions = api.portal.get_registry_record(
         "collective.contact.core.interfaces.IContactCoreParameters."

--- a/src/collective/contact/core/tests/test_search.py
+++ b/src/collective/contact/core/tests/test_search.py
@@ -43,8 +43,11 @@ class TestSearch(unittest.TestCase, BaseTest):
         self.assertEqual(held_position_searchable_text(gadt)(),
                          u"Général Charles De Gaulle Général de l'armée de terre Armée de terre Émissaire OTAN")
         sergent_pepper = self.sergent_pepper
-        self.assertEqual(held_position_searchable_text(sergent_pepper)(),
-                         u"Mister Pepper Sergent de la brigade LH Armée de terre Corps A Division Alpha Régiment H Brigade LH")
+        self.assertEqual(
+            held_position_searchable_text(sergent_pepper)(),
+            (u"Mister Pepper Sergent de la brigade LH Armée de terre Corps A "
+             u"Division Alpha Régiment H Brigade LH sgt.pepper@armees.fr")
+            )
         pepper = self.pepper
         self.assertEqual(person_sortable_title(pepper)(),
                          "pepper")

--- a/src/collective/contact/core/tests/test_search.py
+++ b/src/collective/contact/core/tests/test_search.py
@@ -94,3 +94,7 @@ class TestSearch(unittest.TestCase, BaseTest):
         results = catalog.searchResults(portal_type='held_position',
                                         end={'query': datetime.date(1971, 1, 1), 'range': 'max'})
         self.assertEqual(len(results), 2)
+        restults = catalog.searchResults(
+            SearchableText='charles.de.gaulle@private.com')
+        self.assertEqual(len(restults), 1)
+        self.assertEqual(restults[0].getPath(), '/plone/mydirectory/degaulle')


### PR DESCRIPTION
if you get smtp errors when sending a newsletter with collectice.contact.mailaction there is no way to search for a contact by email currently.