### PR TITLE
Added 'utils.get_gender_and_number'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 1.20 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Added 'utils.get_gender_and_number' that returns the gender and number of a
+  given list of contacts.  This is useful to manage gender (female/male) and
+  number (singular/plural) for generated words.
+  [gbastien]
 
 1.19 (2018-07-09)
 -----------------

--- a/src/collective/contact/core/tests/test_utils.py
+++ b/src/collective/contact/core/tests/test_utils.py
@@ -1,0 +1,67 @@
+# -*- coding: utf8 -*-
+import unittest2 as unittest
+
+from ecreall.helpers.testing.base import BaseTest
+from plone.app.testing.interfaces import TEST_USER_NAME
+
+from collective.contact.core.testing import INTEGRATION
+from collective.contact.core.utils import get_gender_and_number
+
+
+class TestUtils(unittest.TestCase, BaseTest):
+
+    layer = INTEGRATION
+
+    def setUp(self):
+        super(TestUtils, self).setUp()
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        mydirectory = self.portal['mydirectory']
+        self.degaulle = mydirectory['degaulle']
+        self.pepper = mydirectory['pepper']
+        self.sergent_pepper = self.pepper['sergent_pepper']
+        self.draper = mydirectory['draper']
+        self.rambo = mydirectory['rambo']
+        self.armeedeterre = mydirectory['armeedeterre']
+        self.captain_crunch = self.draper['captain_crunch']
+        self.mydirectory = mydirectory
+
+    def test_get_gender_and_number(self):
+        """ """
+        self.login(TEST_USER_NAME)
+
+        # if only non genderable contacts, returns None
+        self.assertIsNone(get_gender_and_number([]))
+        self.assertIsNone(get_gender_and_number([self.armeedeterre]))
+
+        # possible to pass mix of different types of contact
+        self.assertEqual(
+            get_gender_and_number([self.armeedeterre, self.sergent_pepper]), u'MS')
+        self.assertEqual(
+            get_gender_and_number([self.degaulle, self.sergent_pepper]), u'MP')
+
+        # Male, Singular
+        self.assertEqual(
+            get_gender_and_number([self.sergent_pepper]), u'MS')
+        # Male, Plural
+        self.assertEqual(
+            get_gender_and_number([self.sergent_pepper, self.degaulle]), u'MP')
+
+        # change gender to have females
+        self.rambo.gender = u'F'
+        self.draper.gender = u'F'
+        # Female, Singular
+        self.assertEqual(
+            get_gender_and_number([self.rambo]), u'FS')
+        # Female, Plural
+        self.assertEqual(
+            get_gender_and_number([self.rambo, self.draper]), u'FP')
+
+        # Male have priority over Female
+        # Male, Plural
+        self.assertEqual(
+            get_gender_and_number([self.sergent_pepper, self.draper]), u'MP')
+
+        # user unicity, if we pass twice same person, it stays singular, even thru held_position
+        self.assertEqual(
+            get_gender_and_number([self.pepper, self.sergent_pepper]), u'MS')

--- a/src/collective/contact/core/tests/test_utils.py
+++ b/src/collective/contact/core/tests/test_utils.py
@@ -1,11 +1,11 @@
 # -*- coding: utf8 -*-
-import unittest2 as unittest
-
-from ecreall.helpers.testing.base import BaseTest
-from plone.app.testing.interfaces import TEST_USER_NAME
 
 from collective.contact.core.testing import INTEGRATION
 from collective.contact.core.utils import get_gender_and_number
+from ecreall.helpers.testing.base import BaseTest
+from plone.app.testing.interfaces import TEST_USER_NAME
+
+import unittest2 as unittest
 
 
 class TestUtils(unittest.TestCase, BaseTest):

--- a/src/collective/contact/core/utils.py
+++ b/src/collective/contact/core/utils.py
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+from collective.contact.core.content.person import IPerson
+from collective.contact.core.interfaces import IHeldPosition
+
+
+def get_gender_and_number(contacts):
+    """Return gender and number of given contacts.
+       Returns None if not genderable.
+       Returns a 2 letters code if genderable:
+       - first letter is for gender, M for "male", "F" for female;
+       - second letter is for number, S for "Singular", "P" for "Plural".
+       p_contacts may be any kind of contacts, we will try to get person of it."""
+    gender = None
+    number = 0
+    # make sure we do not have several times same person even thru held_position
+    person_uids = []
+    for contact in contacts:
+        person = None
+        if IHeldPosition.providedBy(contact):
+            person = contact.get_person()
+        elif IPerson.providedBy(contact):
+            person = contact
+        if person:
+            person_uid = person.UID()
+            if person_uid in person_uids:
+                continue
+            else:
+                person_uids.append(person_uid)
+            person_gender = person.gender
+            if person_gender in [u'M', u'F']:
+                number = number + 1
+            # "M" takes priority, if already found, we keep it
+            if gender != 'M':
+                gender = person_gender
+    res = gender
+    if gender:
+        res = gender + (number > 1 and 'P' or 'S')
+    return res


### PR DESCRIPTION
 that returns the gender and number of a given list of contacts.  This is useful to manage gender (female/male) and number (singular/plural) for generated words.