### PR TITLE
On persons listed on the directory view, display held_positions when hovering person title (tooltip).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 1.21 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- On persons listed on the directory view, display held_positions when hovering
+  person title (tooltip).
+  [gbastien]
 
 1.20 (2018-07-20)
 -----------------

--- a/src/collective/contact/core/browser/templates/directory.pt
+++ b/src/collective/contact/core/browser/templates/directory.pt
@@ -32,7 +32,7 @@
         <h2><tal:block i18n:translate="">Persons</tal:block>:</h2>
         <ul>
         <tal:block tal:repeat="person view/persons">
-            <li><a tal:attributes="href person/getURL">
+            <li><a class="link-tooltip" tal:attributes="href person/getURL">
                 <img tal:attributes="src person/getIconURL" />
                 <span tal:replace="person/Title"
                       i18n:translate="" />


### PR DESCRIPTION
Hi @vincentfretin @frisi @sgeulette 

I just added the "tooltip" class on the persons displayed on the directory view so it displays held positions.

For users not using collective.contact.facetednav, it is useful ;-)

Could you please review and merge?

Thank you!

Gauthier