### PR TITLE
Make it easy to override the way sub organizations are displayed on an organization by calling a @@suborganizations view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - On persons listed on the directory view, display held_positions when hovering
   person title (tooltip).
   [gbastien]
+- Make it easy to override the way sub organizations are displayed on an
+  organization by calling a @@suborganizations view.
+  [gbastien]
 
 1.20 (2018-07-20)
 -----------------

--- a/src/collective/contact/core/browser/configure.zcml
+++ b/src/collective/contact/core/browser/configure.zcml
@@ -29,6 +29,14 @@
       />
 
   <browser:page
+      name="suborganizations"
+      for="collective.contact.core.content.organization.IOrganization"
+      class=".organization.SubOrganizations"
+      template="templates/suborganizations.pt"
+      permission="zope2.View"
+      />
+
+  <browser:page
       name="view"
       for="..content.position.IPosition"
       class=".position.Position"

--- a/src/collective/contact/core/browser/organization.py
+++ b/src/collective/contact/core/browser/organization.py
@@ -64,6 +64,19 @@ class Organization(BaseView):
         return self.context.toLocalizedTime(date_to_DateTime(date))
 
 
+class SubOrganizations(BaseView):
+
+    def update(self):
+        super(SubOrganizations, self).update()
+
+        catalog = api.portal.get_tool('portal_catalog')
+        context_path = '/'.join(self.context.getPhysicalPath())
+        self.sub_organizations = catalog.searchResults(portal_type="organization",
+                                                       path={'query': context_path,
+                                                             'depth': 1},
+                                                       sort_on='getObjPositionInParent')
+
+
 class OtherContacts(grok.View):
     """Displays other contacts list"""
     grok.name('othercontacts')

--- a/src/collective/contact/core/browser/templates/organization.pt
+++ b/src/collective/contact/core/browser/templates/organization.pt
@@ -33,17 +33,7 @@
 
     <metal:additional-fields use-macro="context/contact_core_macros/macros/additional-fields" />
 
-    <div id="sub_organizations" class="field" tal:condition="view/sub_organizations">
-        <label><tal:block i18n:translate="">Organizations in this organization</tal:block>:</label>
-        <ul>
-        <tal:block tal:repeat="sub_org view/sub_organizations">
-            <li><img tal:attributes="src string:${portal_url}/${sub_org/getIcon}" /> <a tal:attributes="href sub_org/getURL">
-                <span tal:replace="sub_org/Title"
-                      i18n:translate="" />
-            </a></li>
-        </tal:block>
-        </ul>
-    </div>
+    <div tal:replace="structure context/@@suborganizations" />
 
     <div id="positions" class="field" tal:condition="view/positions">
         <label><tal:block i18n:translate="">Positions in this organization</tal:block>:</label>


### PR DESCRIPTION
Hi @vincentfretin @sgeulette 

I need to override the way sub organizations are displayed on an organization, and I prefer not override the entire organization.pt

I just replaced moved this part to a separated view "@@suborganizations" that is called in the organization view.  By default rendering is same as before.

Thank you for reviewing and merging ;-)

Gauthier