### PR TITLE
Added parameter `include_person_title=True` to `person.get_title` and to `held_position.get_person_title` so we get person `firstname/lastname` without `person_title`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changelog
   [gbastien]
 - Make `held_position.get_title` return unicode.
   [gbastien]
+- Added parameter `include_person_title=True` to `person.get_title` and to
+  `held_position.get_person_title` so we get person `firstname/lastname`
+  without `person_title`.
+  [gbastien]
 
 1.22 (2018-10-12)
 -----------------

--- a/src/collective/contact/core/content/held_position.py
+++ b/src/collective/contact/core/content/held_position.py
@@ -112,7 +112,7 @@ class HeldPosition(Container):
         person = self.get_person()
         if person is None:
             return u""
-        return person.get_title(include_person_title=True)
+        return person.get_title(include_person_title=include_person_title)
 
     def get_sortable_title(self):
         person = self.get_person()

--- a/src/collective/contact/core/content/held_position.py
+++ b/src/collective/contact/core/content/held_position.py
@@ -108,11 +108,11 @@ class HeldPosition(Container):
         else:
             return u"%s, %s" % (person_name, title)
 
-    def get_person_title(self):
+    def get_person_title(self, include_person_title=True):
         person = self.get_person()
         if person is None:
             return u""
-        return person.get_title()
+        return person.get_title(include_person_title=True)
 
     def get_sortable_title(self):
         person = self.get_person()

--- a/src/collective/contact/core/content/person.py
+++ b/src/collective/contact/core/content/person.py
@@ -98,14 +98,17 @@ class Person(Container):
     def set_title(self, val):
         return
 
-    def get_title(self):
+    def get_title(self, include_person_title=True):
         displayed_attrs = ('person_title', 'firstname', 'lastname')
-        registry = queryUtility(IRegistry)
-        if registry is not None:
-            record = registry.forInterface(IContactCoreParameters, None)
-            if record is not None:
-                if not record.person_title_in_title:
-                    displayed_attrs = ('firstname', 'lastname')
+        if not include_person_title:
+            displayed_attrs = ('firstname', 'lastname')
+        else:
+            registry = queryUtility(IRegistry)
+            if registry is not None:
+                record = registry.forInterface(IContactCoreParameters, None)
+                if record is not None:
+                    if not record.person_title_in_title:
+                        displayed_attrs = ('firstname', 'lastname')
 
         displayed = [getattr(self, attr, None) for attr in displayed_attrs]
         return u' '.join([x for x in displayed if x])

--- a/src/collective/contact/core/tests/test_content_types.py
+++ b/src/collective/contact/core/tests/test_content_types.py
@@ -6,7 +6,9 @@ import datetime
 
 from ecreall.helpers.testing.base import BaseTest
 
+from collective.contact.core.interfaces import IContactCoreParameters
 from collective.contact.core.testing import INTEGRATION
+from plone import api
 from plone.app.testing.interfaces import TEST_USER_ID, TEST_USER_NAME
 from plone.app.testing.helpers import setRoles
 
@@ -237,8 +239,16 @@ class TestHeldPosition(TestContentTypes):
         self.assertEqual(self.sergent_pepper.get_full_title(),
                          u"Mister Pepper, Sergent de la brigade LH (Armée de terre / Corps A / Division Alpha / "
                          u"Régiment H / Brigade LH)")
+
+    def test_get_person_title(self):
         self.assertEqual(self.gadt.get_person_title(),
                          u"Général Charles De Gaulle")
+        self.assertEqual(self.gadt.get_person_title(include_person_title=False),
+                         u"Charles De Gaulle")
+        api.portal.set_registry_record(
+            name='person_title_in_title', value=False, interface=IContactCoreParameters)
+        self.assertEqual(self.gadt.get_person_title(include_person_title=True),
+                         u"Charles De Gaulle")
 
     def test_get_person(self):
         pass

--- a/src/collective/contact/core/vocabulary.py
+++ b/src/collective/contact/core/vocabulary.py
@@ -2,7 +2,6 @@ from Acquisition import aq_parent
 
 from zope.schema.vocabulary import SimpleVocabulary
 from zope.schema.interfaces import IVocabularyFactory
-from zope.globalrequest import getRequest
 
 from five import grok
 
@@ -52,7 +51,7 @@ class OrganizationTypesOrLevels(grok.GlobalUtility):
     grok.implements(IVocabularyFactory)
 
     def get_container_type(self, context):
-        request = getRequest()
+        request = context.REQUEST
         if request and "++add++organization" in request.getURL():
             # creation mode
             return context.portal_type

--- a/src/collective/contact/core/vocabulary.py
+++ b/src/collective/contact/core/vocabulary.py
@@ -52,7 +52,8 @@ class OrganizationTypesOrLevels(grok.GlobalUtility):
     grok.implements(IVocabularyFactory)
 
     def get_container_type(self, context):
-        if "++add++organization" in getRequest().getURL():
+        request = getRequest()
+        if request and "++add++organization" in request.getURL():
             # creation mode
             return context.portal_type
         else:


### PR DESCRIPTION
Hi @vincentfretin @sgeulette 

Could you please review and merge?

For now it is possible to hide person_title when using person.get_title by defining a value in the registry, here we have a "per call" possibility to show or hide person_title when displaying person get_title.

Gauthier