### PR TITLE
Add robot tests for prefiltering on contact widgets

### DIFF
--- a/src/collective/contact/core/profiles/testing/types/testtype.xml
+++ b/src/collective/contact/core/profiles/testing/types/testtype.xml
@@ -22,6 +22,7 @@
  	<element value="collective.contact.core.behaviors.IContactDetails" />
  	<element value="collective.contact.core.behaviors.IGlobalPositioning" />
  	<element value="collective.contact.core.behaviors.IBirthday" />
+ 	<element value="collective.contact.core.testing.IPrefiltering" />
 </property>
  <property name="schema" />
  <!-- DO NOT use a model_source or it removes manually added fields while reapplying the profile -->

--- a/src/collective/contact/core/testing.py
+++ b/src/collective/contact/core/testing.py
@@ -5,12 +5,60 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-
 from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
 
 from plone.testing import z2
-
+from collective.contact.widget.schema import ContactChoice
+from collective.contact.widget.schema import ContactList
+from collective.contact.widget.source import ContactSourceBinder
+from zope.interface import alsoProvides
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 import collective.contact.core
+
+
+static_prefilter_vocabulary = SimpleVocabulary(
+    [
+        SimpleTerm(value=u'', title=u'No filter'),
+        SimpleTerm(value=u'{"portal_type":"person"}', title=u'Only people'),
+        SimpleTerm(value=u'{"portal_type":"organization"}', title=u'Only organizations'),
+    ]
+)
+
+
+def prefilter_default_value(context):
+    return u'{"portal_type":"organization"}'
+
+
+class IPrefiltering(model.Schema):
+
+    contact_list_no_default = ContactList(
+        title=u'Contact list (no default)',
+        required=True,
+        value_type=ContactChoice(
+            source=ContactSourceBinder(
+                portal_type=("organization", 'held_position', 'person', 'contact_list'),
+            )
+        ),
+        prefilter_vocabulary=static_prefilter_vocabulary,
+    )
+
+    contact_list_with_contextual_default = ContactList(
+        title=u'Contact list (with contextual default)',
+        required=True,
+        value_type=ContactChoice(
+            source=ContactSourceBinder(
+                portal_type=("organization", 'held_position', 'person', 'contact_list'),
+            )
+        ),
+        prefilter_vocabulary=static_prefilter_vocabulary,
+        prefilter_default_value=prefilter_default_value,
+    )
+
+
+alsoProvides(IPrefiltering, IFormFieldProvider)
 
 
 class ContactContentLayer(PloneWithPackageLayer):

--- a/src/collective/contact/core/testing.zcml
+++ b/src/collective/contact/core/testing.zcml
@@ -3,11 +3,17 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="collective.contact.core">
 
   <include file="configure.zcml" />
 
   <include package="ecreall.helpers.testing" />
+
+  <plone:behavior
+    title="Contact lists"
+    provides=".testing.IPrefiltering"
+    />
 
   <genericsetup:registerProfile
       name="testing"

--- a/src/collective/contact/core/tests/robot/test_prefilter.robot
+++ b/src/collective/contact/core/tests/robot/test_prefilter.robot
@@ -1,0 +1,53 @@
+*** Settings ***
+Test Setup        Open SauceLabs test browser
+Test Teardown     Run keywords    Report test status    Close all browsers
+Resource          plone/app/robotframework/keywords.robot    #Test Setup    Open test browser    #Test Teardown    Close all browsers
+Resource          plone/app/robotframework/saucelabs.robot
+Resource          keywords.robot
+
+
+*** Test cases ***
+With and without default value
+    Add test type
+    List Selection Should Be  css:#form-widgets-IPrefiltering-contact_list_no_default-autocomplete .prefilter-select  No filter
+    List Selection Should Be  css:#form-widgets-IPrefiltering-contact_list_with_contextual_default-autocomplete .prefilter-select  Only organizations
+
+Without prefilter
+    Add test type
+    Input Text  css:#form-widgets-IPrefiltering-contact_list_no_default-widgets-query  Pepper
+    Autocomplete results should contain  Pepper
+
+With prefilter
+    Add test type
+    Input Text  css:#form-widgets-IPrefiltering-contact_list_with_contextual_default-widgets-query  Pepper
+    Sleep  5
+    Autocomplete results should not contain  Pepper
+
+Selecting another prefilter
+    Add test type
+    Select From List By Label  css:#form-widgets-IPrefiltering-contact_list_with_contextual_default-autocomplete .prefilter-select  Only people
+    Input Text  css:#form-widgets-IPrefiltering-contact_list_no_default-widgets-query  Pepper
+    Autocomplete results should contain  Pepper
+
+
+*** Keywords ***
+Go to directory
+    Go to    ${PLONE_URL}/mydirectory
+
+Log in as site owner and wait
+    Log in as site owner
+    Wait until page contains    admin
+
+Add test type
+    Log in as site owner and wait
+    Go to    ${PLONE_URL}
+    Add new    testtype
+
+Autocomplete results should contain
+    [Arguments]    ${value}
+    Wait Until Element Is Visible  xpath://div[@class="ac_results"]
+    Element Should Be Visible  xpath://div[@class="ac_results"]/ul/li/strong[text()='${value}']
+
+Autocomplete results should not contain
+    [Arguments]    ${value}
+    Page Should Not Contain Element  xpath://div[@class="ac_results"]/ul/li/strong[text()='${value}']


### PR DESCRIPTION
The tests depend on this pull request: https://github.com/collective/collective.contact.widget/pull/16